### PR TITLE
[feat][#10] Add natural language SF Symbol search using Foundation Models

### DIFF
--- a/SF-Symbol-Finder.xcodeproj/project.pbxproj
+++ b/SF-Symbol-Finder.xcodeproj/project.pbxproj
@@ -24,6 +24,9 @@
 		ADD4C03A2B95C75000B6E862 /* CanvasView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADD4C0392B95C75000B6E862 /* CanvasView.swift */; };
 		ADD4C03C2B95C81B00B6E862 /* functions.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADD4C03B2B95C81B00B6E862 /* functions.swift */; };
 		ADD4C03E2B95C86300B6E862 /* ResultView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADD4C03D2B95C86300B6E862 /* ResultView.swift */; };
+		CC0000012C8A000100000001 /* SymbolKeywords.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0000022C8A000100000001 /* SymbolKeywords.swift */; };
+		CC0000032C8A000100000001 /* FoundationModelService.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0000042C8A000100000001 /* FoundationModelService.swift */; };
+		CC0000052C8A000100000001 /* NaturalLanguageSearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0000062C8A000100000001 /* NaturalLanguageSearchView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -47,6 +50,9 @@
 		ADD4C0392B95C75000B6E862 /* CanvasView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CanvasView.swift; sourceTree = "<group>"; };
 		ADD4C03B2B95C81B00B6E862 /* functions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = functions.swift; sourceTree = "<group>"; };
 		ADD4C03D2B95C86300B6E862 /* ResultView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResultView.swift; sourceTree = "<group>"; };
+		CC0000022C8A000100000001 /* SymbolKeywords.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SymbolKeywords.swift; sourceTree = "<group>"; };
+		CC0000042C8A000100000001 /* FoundationModelService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoundationModelService.swift; sourceTree = "<group>"; };
+		CC0000062C8A000100000001 /* NaturalLanguageSearchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NaturalLanguageSearchView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -99,6 +105,7 @@
 			isa = PBXGroup;
 			children = (
 				ADD4C02F2B95C27E00B6E862 /* Models */,
+				CC0000072C8A000100000001 /* Services */,
 				ADD4C02A2B95BD8A00B6E862 /* Utils */,
 				ADD4C0272B95BD6300B6E862 /* Extensions */,
 				ADD4C0202B95BCC500B6E862 /* Presentations */,
@@ -121,6 +128,7 @@
 			children = (
 				ADD4C0242B95BD3500B6E862 /* Common */,
 				ADD4C0212B95BCCE00B6E862 /* Main */,
+				CC0000082C8A000100000001 /* NaturalLanguageSearch */,
 			);
 			path = Presentations;
 			sourceTree = "<group>";
@@ -167,6 +175,7 @@
 			children = (
 				ADD4C0302B95C28500B6E862 /* Result.swift */,
 				AD548E0C2B960C6200FBB2CC /* DeviceModel.swift */,
+				CC0000022C8A000100000001 /* SymbolKeywords.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -179,6 +188,22 @@
 				ADD4C03B2B95C81B00B6E862 /* functions.swift */,
 			);
 			path = "ContentView+Extension";
+			sourceTree = "<group>";
+		};
+		CC0000072C8A000100000001 /* Services */ = {
+			isa = PBXGroup;
+			children = (
+				CC0000042C8A000100000001 /* FoundationModelService.swift */,
+			);
+			path = Services;
+			sourceTree = "<group>";
+		};
+		CC0000082C8A000100000001 /* NaturalLanguageSearch */ = {
+			isa = PBXGroup;
+			children = (
+				CC0000062C8A000100000001 /* NaturalLanguageSearchView.swift */,
+			);
+			path = NaturalLanguageSearch;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -267,6 +292,9 @@
 				AD8F1C512BA32D5600B8A725 /* CanvasRepresentingView.swift in Sources */,
 				ADD4C0312B95C28500B6E862 /* Result.swift in Sources */,
 				ADD4C02C2B95BD9900B6E862 /* Constants.swift in Sources */,
+				CC0000012C8A000100000001 /* SymbolKeywords.swift in Sources */,
+				CC0000032C8A000100000001 /* FoundationModelService.swift in Sources */,
+				CC0000052C8A000100000001 /* NaturalLanguageSearchView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/SF-Symbol-Finder/Resources/en.lproj/Localizable.strings
+++ b/SF-Symbol-Finder/Resources/en.lproj/Localizable.strings
@@ -24,3 +24,11 @@
 /* SFSymbolListView*/
 "GuideOnClickToCopy" = "Click to copy the name to the clipboard";
 "AlertCopied" = "Copied to clipboard";
+
+/* NaturalLanguageSearchView */
+"SearchModeDraw" = "Draw";
+"SearchModeDescribe" = "Describe";
+"NLSearchPlaceholder" = "Describe the symbol (e.g. icon for share button)";
+"NLSearchGuide" = "Describe the SF Symbol you're looking for,\nand we'll find it for you.";
+"NLSearching" = "Searching for symbols...";
+"NLNoResults" = "No matching symbols found.\nTry a different description.";

--- a/SF-Symbol-Finder/Resources/ko.lproj/Localizable.strings
+++ b/SF-Symbol-Finder/Resources/ko.lproj/Localizable.strings
@@ -24,3 +24,11 @@
 /* SFSymbolListView*/
 "GuideOnClickToCopy" = "클릭하여 클립보드에 심볼 이름을 복사할 수 있어요";
 "AlertCopied" = "클립보드에 복사되었어요";
+
+/* NaturalLanguageSearchView */
+"SearchModeDraw" = "그리기";
+"SearchModeDescribe" = "설명하기";
+"NLSearchPlaceholder" = "심볼을 설명해 주세요 (예: 공유 버튼에 쓸 아이콘)";
+"NLSearchGuide" = "찾고 싶은 SF Symbol을 설명하면\n해당하는 심볼을 찾아드릴게요.";
+"NLSearching" = "심볼을 검색하는 중...";
+"NLNoResults" = "일치하는 심볼을 찾지 못했어요.\n다른 설명을 시도해 보세요.";

--- a/SF-Symbol-Finder/Sources/Extensions/String+Extension.swift
+++ b/SF-Symbol-Finder/Sources/Extensions/String+Extension.swift
@@ -39,6 +39,14 @@ extension String {
     static let guideOnClickToCopy = "GuideOnClickToCopy".localized()
     static let alertCopied = "AlertCopied".localized()
 
+    /* NaturalLanguageSearchView */
+    static let searchModeDraw = "SearchModeDraw".localized()
+    static let searchModeDescribe = "SearchModeDescribe".localized()
+    static let nlSearchPlaceholder = "NLSearchPlaceholder".localized()
+    static let nlSearchGuide = "NLSearchGuide".localized()
+    static let nlSearching = "NLSearching".localized()
+    static let nlNoResults = "NLNoResults".localized()
+
 }
 
 // MARK: - SF Symbols

--- a/SF-Symbol-Finder/Sources/Models/SymbolKeywords.swift
+++ b/SF-Symbol-Finder/Sources/Models/SymbolKeywords.swift
@@ -1,0 +1,17 @@
+//
+//  SymbolKeywords.swift
+//  SF-Symbol-Finder
+//
+//  Created by ZENA on 2026/03/04.
+//
+
+#if canImport(FoundationModels)
+import FoundationModels
+
+@available(iOS 26.0, *)
+@Generable
+struct SymbolKeywords {
+    /// SF Symbol 이름을 구성하는 영어 키워드 배열 (예: ["heart", "plus", "fill"])
+    var keywords: [String]
+}
+#endif

--- a/SF-Symbol-Finder/Sources/Presentations/Main/ContentView.swift
+++ b/SF-Symbol-Finder/Sources/Presentations/Main/ContentView.swift
@@ -9,6 +9,18 @@ import SwiftUI
 import CoreML
 import Vision
 
+enum SearchMode: String, CaseIterable {
+    case describe
+    case draw
+
+    var title: String {
+        switch self {
+        case .draw: return String.searchModeDraw
+        case .describe: return String.searchModeDescribe
+        }
+    }
+}
+
 struct ContentView: View {
     @State var isClear = false
     @State var canvasRepresentingView: CanvasRepresentingView?
@@ -18,20 +30,33 @@ struct ContentView: View {
     @State var selectedLabel = ""
     @State var showErrorAlert = false
     @State var onAppeared = false
+    @State private var searchMode: SearchMode = .describe
+    #if canImport(FoundationModels)
+    @StateObject private var nlSearchViewModel = {
+        if #available(iOS 26.0, *) {
+            return NaturalLanguageSearchViewModel()
+        } else {
+            fatalError()
+        }
+    }()
+    #endif
     @EnvironmentObject var orientation: Orientation
     var defaultPadding: CGFloat {
         Constants.deviceModel == DeviceModel.iPad.rawValue ? 30 : 10
     }
-    
+
     var body: some View {
         ZStack {
             Color.neutral.ignoresSafeArea()
-            if orientation.orientation == .portrait {
-                contentsInVStack
-            } else {
-                contentsInHStack
+            VStack(spacing: 0) {
+                searchModePicker
+                if searchMode == .draw {
+                    drawContent
+                } else {
+                    describeContent
+                }
             }
-            
+
             if showErrorAlert {
                 Color.black
                     .opacity(0.8)
@@ -58,6 +83,41 @@ struct ContentView: View {
                 onAppeared = true
             }
         }
+    }
+
+    @ViewBuilder
+    private var searchModePicker: some View {
+        #if canImport(FoundationModels)
+        if #available(iOS 26.0, *) {
+            Picker("", selection: $searchMode) {
+                ForEach(SearchMode.allCases, id: \.self) { mode in
+                    Text(mode.title).tag(mode)
+                }
+            }
+            .pickerStyle(.segmented)
+            .padding(.horizontal, defaultPadding)
+            .padding(.top, 8)
+        }
+        #endif
+    }
+
+    private var drawContent: some View {
+        Group {
+            if orientation.orientation == .portrait {
+                contentsInVStack
+            } else {
+                contentsInHStack
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var describeContent: some View {
+        #if canImport(FoundationModels)
+        if #available(iOS 26.0, *) {
+            NaturalLanguageSearchView(viewModel: nlSearchViewModel)
+        }
+        #endif
     }
     
     private var contentsInHStack: some View {

--- a/SF-Symbol-Finder/Sources/Presentations/Main/SFSymbolListView.swift
+++ b/SF-Symbol-Finder/Sources/Presentations/Main/SFSymbolListView.swift
@@ -16,6 +16,7 @@ struct SFSymbolListView: View {
         return Constants.sfsymbols.filter({ $0.contains(keywordReplaced)})
     }
     @State private var showClipboardAlert = false
+    @State private var selectedSymbol: String?
     @Environment(\.dismiss) private var dismiss
     var body: some View {
         ZStack {
@@ -30,7 +31,7 @@ struct SFSymbolListView: View {
                             ZStack {
                                 Rectangle()
                                     .stroke(Color.accentColor, lineWidth: 0.5)
-                                    .background(Color.neutral)
+                                    .background(selectedSymbol == systemName ? Color.accentColor.opacity(0.3) : Color.neutral)
                                 HStack(spacing: 10) {
                                     Image(systemName: systemName)
                                         .font(.largeTitle)
@@ -45,7 +46,11 @@ struct SFSymbolListView: View {
                             }
                             .onTapGesture {
                                 UIPasteboard.general.string = systemName
+                                selectedSymbol = systemName
                                 showClipboardAlert = true
+                                DispatchQueue.main.asyncAfter(deadline: .now() + 0.7) {
+                                    selectedSymbol = nil
+                                }
                             }
                         }
                     }

--- a/SF-Symbol-Finder/Sources/Presentations/NaturalLanguageSearch/NaturalLanguageSearchView.swift
+++ b/SF-Symbol-Finder/Sources/Presentations/NaturalLanguageSearch/NaturalLanguageSearchView.swift
@@ -1,0 +1,199 @@
+//
+//  NaturalLanguageSearchView.swift
+//  SF-Symbol-Finder
+//
+//  Created by ZENA on 2026/03/04.
+//
+
+#if canImport(FoundationModels)
+import SwiftUI
+
+@available(iOS 26.0, *)
+final class NaturalLanguageSearchViewModel: ObservableObject {
+    @Published var searchText = ""
+    @Published var searchResults: [String] = []
+    @Published var isSearching = false
+    @Published var hasSearched = false
+
+    private let service = FoundationModelService()
+
+    func performSearch() {
+        let query = searchText.trimmingCharacters(in: .whitespaces)
+        guard !query.isEmpty else { return }
+
+        isSearching = true
+        hasSearched = true
+        searchResults = []
+
+        Task {
+            do {
+                let results = try await service.searchSymbols(for: query)
+                await MainActor.run {
+                    self.searchResults = results
+                    self.isSearching = false
+                }
+            } catch {
+                await MainActor.run {
+                    self.isSearching = false
+                }
+            }
+        }
+    }
+}
+
+@available(iOS 26.0, *)
+struct NaturalLanguageSearchView: View {
+    @ObservedObject var viewModel: NaturalLanguageSearchViewModel
+    @State private var showClipboardAlert = false
+    @State private var selectedSymbol: String?
+    @FocusState private var isTextFieldFocused: Bool
+
+    var body: some View {
+        ZStack {
+            Color.neutral.ignoresSafeArea()
+
+            VStack(spacing: 16) {
+                searchBar
+                resultContent
+            }
+            .padding()
+
+            if showClipboardAlert {
+                clipboardAlert
+            }
+        }
+    }
+
+    private var searchBar: some View {
+        HStack(spacing: 12) {
+            HStack(spacing: 8) {
+                Image(systemName: "magnifyingglass")
+                    .foregroundStyle(.gray)
+                    .font(.subheadline)
+                TextField("", text: $viewModel.searchText, prompt: Text(String.nlSearchPlaceholder).foregroundColor(.white.opacity(0.5)))
+                    .font(.subheadline)
+                    .foregroundStyle(.white)
+                    .focused($isTextFieldFocused)
+                    .submitLabel(.search)
+                    .onSubmit { viewModel.performSearch() }
+                if !viewModel.searchText.isEmpty {
+                    Button {
+                        viewModel.searchText = ""
+                        viewModel.searchResults = []
+                        viewModel.hasSearched = false
+                        isTextFieldFocused = true
+                    } label: {
+                        Image(systemName: "xmark.circle.fill")
+                            .foregroundStyle(.gray)
+                            .font(.subheadline)
+                    }
+                }
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 10)
+            .frame(minHeight: 44)
+            .background(
+                RoundedRectangle(cornerRadius: 12)
+                    .fill(Color.white.opacity(0.08))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 12)
+                    .stroke(Color.gray.opacity(0.3), lineWidth: 0.5)
+            )
+
+            Button {
+                isTextFieldFocused = false
+                viewModel.performSearch()
+            } label: {
+                Image(systemName: "arrow.right.circle.fill")
+                    .font(.title2)
+                    .foregroundStyle(Color.accentColor)
+            }
+            .disabled(viewModel.searchText.trimmingCharacters(in: .whitespaces).isEmpty || viewModel.isSearching)
+            .opacity(viewModel.searchText.trimmingCharacters(in: .whitespaces).isEmpty ? 0.4 : 1.0)
+        }
+    }
+
+    @ViewBuilder
+    private var resultContent: some View {
+        if viewModel.isSearching {
+            Spacer()
+            ProgressView()
+                .tint(.white)
+            Text(String.nlSearching)
+                .foregroundStyle(.gray)
+            Spacer()
+        } else if viewModel.searchResults.isEmpty {
+            Spacer()
+            Text(viewModel.hasSearched ? String.nlNoResults : String.nlSearchGuide)
+                .font(.body)
+                .foregroundStyle(.gray)
+                .multilineTextAlignment(.center)
+            Spacer()
+        } else {
+            Text(String.guideOnClickToCopy)
+                .font(.headline)
+                .foregroundStyle(Color.accentColor)
+
+            HStack(spacing: 0) {
+                ScrollView {
+                    LazyVGrid(columns: [GridItem()]) {
+                        ForEach(viewModel.searchResults, id: \.self) { symbolName in
+                            ZStack {
+                                Rectangle()
+                                    .stroke(Color.accentColor, lineWidth: 0.5)
+                                    .background(selectedSymbol == symbolName ? Color.accentColor.opacity(0.3) : Color.neutral)
+                                HStack(spacing: 10) {
+                                    Image(systemName: symbolName)
+                                        .font(.largeTitle)
+                                        .padding()
+                                        .foregroundStyle(.white)
+                                        .frame(width: 80)
+                                    Text(symbolName)
+                                        .font(.subheadline)
+                                        .foregroundStyle(.white)
+                                    Spacer()
+                                }
+                            }
+                            .onTapGesture {
+                                UIPasteboard.general.string = symbolName
+                                selectedSymbol = symbolName
+                                showClipboardAlert = true
+                                DispatchQueue.main.asyncAfter(deadline: .now() + 0.7) {
+                                    selectedSymbol = nil
+                                }
+                            }
+                        }
+                    }
+                    .padding(.trailing, 4)
+                }
+                .scrollDismissesKeyboard(.interactively)
+            }
+        }
+    }
+
+    private var clipboardAlert: some View {
+        ZStack {
+            Color.black.opacity(0.7).ignoresSafeArea()
+            HStack(spacing: 10) {
+                Image(systemName: .docOnClipboard)
+                    .font(.title3)
+                    .foregroundStyle(.white)
+                Text(String.alertCopied)
+                    .font(.title3)
+                    .foregroundStyle(.white)
+            }
+            .padding()
+            .background(
+                RoundedRectangle(cornerRadius: 8)
+                    .foregroundColor(.gray.opacity(0.5))
+            )
+            .onAppear {
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.7) {
+                    showClipboardAlert = false
+                }
+            }
+        }
+    }
+}
+#endif

--- a/SF-Symbol-Finder/Sources/Services/FoundationModelService.swift
+++ b/SF-Symbol-Finder/Sources/Services/FoundationModelService.swift
@@ -1,0 +1,125 @@
+//
+//  FoundationModelService.swift
+//  SF-Symbol-Finder
+//
+//  Created by ZENA on 2026/03/04.
+//
+
+#if canImport(FoundationModels)
+import FoundationModels
+
+@available(iOS 26.0, *)
+final class FoundationModelService {
+
+    private let session: LanguageModelSession
+
+    init() {
+        let instructions = """
+        You are an expert on Apple's SF Symbols and iOS/macOS UI design conventions. \
+        Your job is to think about what the user is describing and return all the SF Symbol name \
+        components that could match — including semantically related ones.
+
+        SF Symbol names use dot-separated keywords like: "heart.fill", "arrow.up.circle", "tortoise.fill".
+
+        IMPORTANT RULES:
+        1. If the user enters keywords that look like SF Symbol name parts (e.g. "heart fill", "arrow up circle"), \
+           include those exact words as keywords. They are directly searching by name.
+        2. If the user describes something in natural language or describes a UI PURPOSE or USE CASE, \
+           think about what SPECIFIC SF Symbol names would be relevant and which symbols are conventionally used \
+           for that purpose in Apple's ecosystem and iOS apps.
+        3. Expand the description into ALL related concrete symbol name keywords.
+
+        UI purpose / use case examples:
+        - "공유 버튼" or "share button" → ["square", "arrow", "up"] (square.and.arrow.up is the standard share icon)
+        - "카테고리" or "category button" → ["square", "grid", "list", "rectangle", "sidebar", "tray"]
+        - "설정" or "settings" → ["gear", "gearshape", "slider", "wrench", "switch"]
+        - "홈" or "home" → ["house", "building"]
+        - "검색" or "search" → ["magnifyingglass"]
+        - "프로필" or "profile" → ["person", "circle", "crop"]
+        - "더보기" or "more menu" → ["ellipsis", "line", "horizontal"]
+        - "뒤로가기" or "back" → ["chevron", "backward", "left", "arrow"]
+        - "닫기" or "close/dismiss" → ["xmark", "multiply"]
+        - "즐겨찾기" or "favorite" → ["star", "heart", "bookmark"]
+        - "다운로드" or "download" → ["arrow", "down", "square", "icloud"]
+        - "삭제" or "delete" → ["trash", "xmark", "minus"]
+        - "새로고침" or "refresh" → ["arrow", "clockwise", "counterclockwise"]
+        - "알림" or "notification" → ["bell", "exclamationmark", "badge"]
+        - "탭바" or "tab bar" → ["house", "magnifyingglass", "person", "gear", "star"]
+        - "필터" or "filter" → ["line", "horizontal", "decrease", "slider"]
+        - "정렬" or "sort" → ["arrow", "up", "down", "line"]
+
+        Semantic / descriptive examples:
+        - "동물" or "animal" → ["tortoise", "hare", "bird", "fish", "ant", "ladybug", "cat", "dog", "pawprint", "lizard", "rabbit", "bear", "dinosaur", "duck", "frog"]
+        - "날씨" or "weather" → ["sun", "moon", "cloud", "rain", "snow", "bolt", "wind", "thermometer", "humidity", "tornado", "snowflake", "rainbow"]
+        - "채워진 하트" or "filled heart" → ["heart", "fill"]
+        - "경고" or "warning" → ["exclamationmark", "warning", "xmark", "nosign", "hand", "stop"]
+        - "음악" or "music" → ["music", "note", "beats", "headphones", "speaker", "waveform", "pianokeys", "guitars", "metronome"]
+        - "사람" or "people" → ["person", "figure", "people"]
+        - "위쪽 화살표" → ["arrow", "up", "chevron"]
+        - "통신" or "communication" → ["phone", "envelope", "message", "bubble", "video", "antenna", "wifi"]
+        - "편집" or "editing" → ["pencil", "scissors", "wand", "crop", "slider", "paintbrush", "eraser", "lasso"]
+        - "올가미" or "lasso" → ["lasso", "sparkles"]
+        - "번역" or "translate" or "통역" → ["translate", "globe", "character", "textformat", "bubble"]
+        - "언어" or "language" or "다국어" → ["globe", "translate", "character", "textformat", "abc"]
+
+        The user may describe symbols in any language including Korean. Always return English keywords.
+        Common Korean-English mappings: 올가미=lasso, 공유=share, 설정=settings/gear, 검색=search/magnifyingglass, \
+        삭제=trash/delete, 즐겨찾기=star/bookmark, 알림=bell/notification, 카메라=camera, 사진=photo, \
+        잠금=lock, 위치=location/map, 달력=calendar, 시계=clock, 폴더=folder, 파일=doc/document, \
+        번역=translate, 통역=translate, 언어=globe/translate.
+        Return as many relevant keywords as possible to maximize search coverage.
+        """
+
+        self.session = LanguageModelSession(instructions: instructions)
+    }
+
+    func searchSymbols(for description: String) async throws -> [String] {
+        // Foundation Model로 키워드 추출 시도
+        var keywords: [String] = []
+
+        if SystemLanguageModel.default.isAvailable {
+            do {
+                let prompt = "What SF Symbol name keywords are related to this description? Think broadly about all symbols that could match: \"\(description)\""
+                let response = try await session.respond(to: prompt, generating: SymbolKeywords.self)
+                keywords = response.content.keywords.map { $0.lowercased() }
+            } catch {
+                // 모델 실패 시 폴백으로 진행
+            }
+        }
+
+        // 모델 미사용/실패 시 직접 키워드 분리
+        if keywords.isEmpty {
+            keywords = description
+                .lowercased()
+                .split(separator: " ")
+                .map(String.init)
+        }
+
+        var matchedSymbols = matchSymbols(with: keywords)
+
+        // 추가 폴백: 키워드 부분 매칭이 안 되면 개별 글자 매칭
+        if matchedSymbols.isEmpty {
+            let singleChars = keywords.flatMap { $0.split(separator: ".").map(String.init) }
+            matchedSymbols = matchSymbols(with: singleChars)
+        }
+
+        return matchedSymbols
+    }
+
+    private func matchSymbols(with keywords: [String]) -> [String] {
+        guard !keywords.isEmpty else { return [] }
+
+        let scored: [(name: String, score: Int)] = Constants.sfsymbols.compactMap { symbolName in
+            let score = keywords.reduce(0) { count, keyword in
+                symbolName.contains(keyword) ? count + 1 : count
+            }
+            return score > 0 ? (symbolName, score) : nil
+        }
+
+        return scored
+            .sorted { $0.score > $1.score }
+            .prefix(50)
+            .map(\.name)
+    }
+}
+#endif


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                                          
  - Apple FoundationModels 프레임워크(iOS 26+)를 활용한 자연어 SF Symbol 검색 기능 추가                                                                                                                               
  - "설명하기" / "그리기" 탭 전환 UI (Segmented Picker)                                                                                                                                                               
  - 자연어 설명 → 키워드 추출 → Constants.sfsymbols 매칭 (최대 50개)                                                                                                                                                  
  - 시뮬레이터 폴백: 모델 미지원 시 직접 키워드 분리 매칭                                                                                                                                                             
  - iOS 25 이하 기존 동작 완전 호환                                                                                                                                                                                   
                                                                                                                                                                                                                      
  ## Changes                                                                                                                                                                                                          
  | 파일 | 작업 |                                                                                                                                                                                                     
  |------|------|                                                                                                                                                                                                     
  | `SymbolKeywords.swift` | `@Generable` 구조체 (새 파일) |                                                                                                                                                          
  | `FoundationModelService.swift` | LanguageSession + 키워드 매칭 서비스 (새 파일) |                                                                                                                                 
  | `NaturalLanguageSearchView.swift` | 자연어 검색 UI (새 파일) |                                                                                                                                                    
  | `ContentView.swift` | SearchMode 탭 전환 추가 |                                                                                                                                                                   
  | `SFSymbolListView.swift` | 셀 선택 이펙트 추가 |                                                                                                                                                                  
  | `String+Extension.swift` | 로컬라이제이션 문자열 추가 |
  | `Localizable.strings (en/ko)` | NL 검색 관련 번역 추가 |

  ## Test plan
  - [ ] iOS 26 실기기에서 자연어 검색 동작 확인
  - [ ] 한글/영어 입력 모두 정상 키워드 추출 확인
  - [ ] UI 용도 기반 검색 확인 (예: "공유 버튼에 쓸 아이콘")
  - [ ] 탭 전환 시 검색 상태 유지 확인
  - [ ] 셀 탭 → 클립보드 복사 + selection effect 확인
  - [ ] 그리기 모드 기존 기능 정상 동작 확인