### PR TITLE
[feat][#10] Foundation Model 개선 및 TabView UI 리뉴얼       

### DIFF
--- a/SF-Symbol-Finder.xcodeproj/project.pbxproj
+++ b/SF-Symbol-Finder.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		57A9B6992F5A9DD200CECF0B /* SearchMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57A9B6982F5A9DD200CECF0B /* SearchMode.swift */; };
 		AD19B5E02BBD9F5100847DF7 /* SFSymbolClassifier.mlmodel in Sources */ = {isa = PBXBuildFile; fileRef = AD19B5DF2BBD9F5100847DF7 /* SFSymbolClassifier.mlmodel */; };
 		AD548E0D2B960C6200FBB2CC /* DeviceModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD548E0C2B960C6200FBB2CC /* DeviceModel.swift */; };
 		AD548E112B96118D00FBB2CC /* Orientation.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD548E102B96118D00FBB2CC /* Orientation.swift */; };
@@ -27,9 +28,11 @@
 		CC0000012C8A000100000001 /* SymbolKeywords.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0000022C8A000100000001 /* SymbolKeywords.swift */; };
 		CC0000032C8A000100000001 /* FoundationModelService.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0000042C8A000100000001 /* FoundationModelService.swift */; };
 		CC0000052C8A000100000001 /* NaturalLanguageSearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0000062C8A000100000001 /* NaturalLanguageSearchView.swift */; };
+		CC0000092C8A000100000001 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC00000A2C8A000100000001 /* SettingsView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		57A9B6982F5A9DD200CECF0B /* SearchMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchMode.swift; sourceTree = "<group>"; };
 		AD19B5DF2BBD9F5100847DF7 /* SFSymbolClassifier.mlmodel */ = {isa = PBXFileReference; lastKnownFileType = file.mlmodel; path = SFSymbolClassifier.mlmodel; sourceTree = "<group>"; };
 		AD548E0C2B960C6200FBB2CC /* DeviceModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceModel.swift; sourceTree = "<group>"; };
 		AD548E102B96118D00FBB2CC /* Orientation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Orientation.swift; sourceTree = "<group>"; };
@@ -53,6 +56,7 @@
 		CC0000022C8A000100000001 /* SymbolKeywords.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SymbolKeywords.swift; sourceTree = "<group>"; };
 		CC0000042C8A000100000001 /* FoundationModelService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoundationModelService.swift; sourceTree = "<group>"; };
 		CC0000062C8A000100000001 /* NaturalLanguageSearchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NaturalLanguageSearchView.swift; sourceTree = "<group>"; };
+		CC00000A2C8A000100000001 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -129,6 +133,7 @@
 				ADD4C0242B95BD3500B6E862 /* Common */,
 				ADD4C0212B95BCCE00B6E862 /* Main */,
 				CC0000082C8A000100000001 /* NaturalLanguageSearch */,
+				CC00000B2C8A000100000001 /* Settings */,
 			);
 			path = Presentations;
 			sourceTree = "<group>";
@@ -140,6 +145,7 @@
 				ADD4C0122B95B96C00B6E862 /* ContentView.swift */,
 				ADD4C0382B95C73900B6E862 /* ContentView+Extension */,
 				ADD4C0362B95C4DB00B6E862 /* SFSymbolListView.swift */,
+				57A9B6982F5A9DD200CECF0B /* SearchMode.swift */,
 			);
 			path = Main;
 			sourceTree = "<group>";
@@ -204,6 +210,14 @@
 				CC0000062C8A000100000001 /* NaturalLanguageSearchView.swift */,
 			);
 			path = NaturalLanguageSearch;
+			sourceTree = "<group>";
+		};
+		CC00000B2C8A000100000001 /* Settings */ = {
+			isa = PBXGroup;
+			children = (
+				CC00000A2C8A000100000001 /* SettingsView.swift */,
+			);
+			path = Settings;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -284,6 +298,7 @@
 				ADD4C0372B95C4DB00B6E862 /* SFSymbolListView.swift in Sources */,
 				AD548E0D2B960C6200FBB2CC /* DeviceModel.swift in Sources */,
 				ADD4C03E2B95C86300B6E862 /* ResultView.swift in Sources */,
+				57A9B6992F5A9DD200CECF0B /* SearchMode.swift in Sources */,
 				ADD4C0132B95B96C00B6E862 /* ContentView.swift in Sources */,
 				AD548E1B2B96F30600FBB2CC /* String+Extension.swift in Sources */,
 				AD548E112B96118D00FBB2CC /* Orientation.swift in Sources */,
@@ -295,6 +310,7 @@
 				CC0000012C8A000100000001 /* SymbolKeywords.swift in Sources */,
 				CC0000032C8A000100000001 /* FoundationModelService.swift in Sources */,
 				CC0000052C8A000100000001 /* NaturalLanguageSearchView.swift in Sources */,
+				CC0000092C8A000100000001 /* SettingsView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/SF-Symbol-Finder/Resources/en.lproj/Localizable.strings
+++ b/SF-Symbol-Finder/Resources/en.lproj/Localizable.strings
@@ -37,6 +37,7 @@
 "NLModelNotEnabled" = "Enable Apple Intelligence to use AI search.\nGo to Settings > Apple Intelligence & Siri to turn it on.\nShowing results from basic keyword search.";
 "NLModelNotReady" = "The AI model is being prepared.\nPlease try again shortly.\nYou can check the status in Settings > Apple Intelligence & Siri.";
 "NLModelError" = "An error occurred during AI search.\nShowing results from basic keyword search.";
+"NLModelDisclaimer" = "Powered by Apple's Foundation Model.\nResults may not always be accurate.";
 
 /* Settings */
 "Settings" = "Settings";

--- a/SF-Symbol-Finder/Resources/en.lproj/Localizable.strings
+++ b/SF-Symbol-Finder/Resources/en.lproj/Localizable.strings
@@ -27,7 +27,8 @@
 
 /* NaturalLanguageSearchView */
 "SearchModeDraw" = "Draw";
-"SearchModeDescribe" = "Describe";
+"SearchModeDescribe" = "All";
+"SearchModeSearch" = "Search";
 "NLSearchPlaceholder" = "Describe the symbol (e.g. icon for share button)";
 "NLSearchGuide" = "Describe the SF Symbol you're looking for,\nand we'll find it for you.";
 "NLSearching" = "Searching for symbols...";
@@ -36,3 +37,14 @@
 "NLModelNotEnabled" = "Enable Apple Intelligence to use AI search.\nGo to Settings > Apple Intelligence & Siri to turn it on.\nShowing results from basic keyword search.";
 "NLModelNotReady" = "The AI model is being prepared.\nPlease try again shortly.\nYou can check the status in Settings > Apple Intelligence & Siri.";
 "NLModelError" = "An error occurred during AI search.\nShowing results from basic keyword search.";
+
+/* Settings */
+"Settings" = "Settings";
+"SettingsLanguage" = "Language";
+"SettingsSFSymbols" = "SF Symbols";
+"SettingsSFSymbolsVersion" = "SF Symbols Version";
+"SettingsSFSymbolsVersionValue" = "5.1";
+"SettingsSFSymbolsCount" = "Symbol Count";
+"SettingsAppInfo" = "App Info";
+"SettingsCurrentVersion" = "Current Version";
+"SettingsChangeLanguage" = "Change Language";

--- a/SF-Symbol-Finder/Resources/en.lproj/Localizable.strings
+++ b/SF-Symbol-Finder/Resources/en.lproj/Localizable.strings
@@ -32,3 +32,7 @@
 "NLSearchGuide" = "Describe the SF Symbol you're looking for,\nand we'll find it for you.";
 "NLSearching" = "Searching for symbols...";
 "NLNoResults" = "No matching symbols found.\nTry a different description.";
+"NLModelDeviceNotEligible" = "AI search is not available on this device.\nPlease use a device that supports Apple Intelligence.\nShowing results from basic keyword search.";
+"NLModelNotEnabled" = "Enable Apple Intelligence to use AI search.\nGo to Settings > Apple Intelligence & Siri to turn it on.\nShowing results from basic keyword search.";
+"NLModelNotReady" = "The AI model is being prepared.\nPlease try again shortly.\nYou can check the status in Settings > Apple Intelligence & Siri.";
+"NLModelError" = "An error occurred during AI search.\nShowing results from basic keyword search.";

--- a/SF-Symbol-Finder/Resources/en.lproj/Localizable.strings
+++ b/SF-Symbol-Finder/Resources/en.lproj/Localizable.strings
@@ -28,7 +28,7 @@
 /* NaturalLanguageSearchView */
 "SearchModeDraw" = "Draw";
 "SearchModeBrowse" = "All";
-"SearchModeSearch" = "Search";
+"SearchModeDescribe" = "Search";
 "NLSearchPlaceholder" = "Describe the symbol (e.g. icon for share button)";
 "NLSearchGuide" = "Describe the SF Symbol you're looking for,\nand we'll find it for you.";
 "NLSearching" = "Searching for symbols...";

--- a/SF-Symbol-Finder/Resources/en.lproj/Localizable.strings
+++ b/SF-Symbol-Finder/Resources/en.lproj/Localizable.strings
@@ -27,7 +27,7 @@
 
 /* NaturalLanguageSearchView */
 "SearchModeDraw" = "Draw";
-"SearchModeDescribe" = "All";
+"SearchModeBrowse" = "All";
 "SearchModeSearch" = "Search";
 "NLSearchPlaceholder" = "Describe the symbol (e.g. icon for share button)";
 "NLSearchGuide" = "Describe the SF Symbol you're looking for,\nand we'll find it for you.";

--- a/SF-Symbol-Finder/Resources/ko.lproj/Localizable.strings
+++ b/SF-Symbol-Finder/Resources/ko.lproj/Localizable.strings
@@ -37,6 +37,7 @@
 "NLModelNotEnabled" = "AI 검색을 사용하려면 Apple Intelligence를 활성화해 주세요.\n설정 > Apple Intelligence 및 Siri에서 켤 수 있어요.\n기본 키워드 검색으로 결과를 표시합니다.";
 "NLModelNotReady" = "AI 모델을 준비하는 중이에요.\n잠시 후 다시 시도해 주세요.\n설정 > Apple Intelligence 및 Siri에서 상태를 확인할 수 있어요.";
 "NLModelError" = "AI 검색 중 오류가 발생했어요.\n기본 키워드 검색으로 결과를 표시합니다.";
+"NLModelDisclaimer" = "Apple의 Foundation Model을 사용합니다.\n결과가 정확하지 않을 수 있습니다.";
 
 /* Settings */
 "Settings" = "설정";

--- a/SF-Symbol-Finder/Resources/ko.lproj/Localizable.strings
+++ b/SF-Symbol-Finder/Resources/ko.lproj/Localizable.strings
@@ -28,7 +28,7 @@
 /* NaturalLanguageSearchView */
 "SearchModeDraw" = "그리기";
 "SearchModeBrowse" = "전체";
-"SearchModeSearch" = "검색";
+"SearchModeDescribe" = "검색";
 "NLSearchPlaceholder" = "심볼을 설명해 주세요 (예: 공유 버튼에 쓸 아이콘)";
 "NLSearchGuide" = "찾고 싶은 SF Symbol을 설명하면\n해당하는 심볼을 찾아드릴게요.";
 "NLSearching" = "심볼을 검색하는 중...";

--- a/SF-Symbol-Finder/Resources/ko.lproj/Localizable.strings
+++ b/SF-Symbol-Finder/Resources/ko.lproj/Localizable.strings
@@ -27,7 +27,7 @@
 
 /* NaturalLanguageSearchView */
 "SearchModeDraw" = "그리기";
-"SearchModeDescribe" = "전체";
+"SearchModeBrowse" = "전체";
 "SearchModeSearch" = "검색";
 "NLSearchPlaceholder" = "심볼을 설명해 주세요 (예: 공유 버튼에 쓸 아이콘)";
 "NLSearchGuide" = "찾고 싶은 SF Symbol을 설명하면\n해당하는 심볼을 찾아드릴게요.";

--- a/SF-Symbol-Finder/Resources/ko.lproj/Localizable.strings
+++ b/SF-Symbol-Finder/Resources/ko.lproj/Localizable.strings
@@ -27,7 +27,8 @@
 
 /* NaturalLanguageSearchView */
 "SearchModeDraw" = "그리기";
-"SearchModeDescribe" = "설명하기";
+"SearchModeDescribe" = "전체";
+"SearchModeSearch" = "검색";
 "NLSearchPlaceholder" = "심볼을 설명해 주세요 (예: 공유 버튼에 쓸 아이콘)";
 "NLSearchGuide" = "찾고 싶은 SF Symbol을 설명하면\n해당하는 심볼을 찾아드릴게요.";
 "NLSearching" = "심볼을 검색하는 중...";
@@ -36,3 +37,14 @@
 "NLModelNotEnabled" = "AI 검색을 사용하려면 Apple Intelligence를 활성화해 주세요.\n설정 > Apple Intelligence 및 Siri에서 켤 수 있어요.\n기본 키워드 검색으로 결과를 표시합니다.";
 "NLModelNotReady" = "AI 모델을 준비하는 중이에요.\n잠시 후 다시 시도해 주세요.\n설정 > Apple Intelligence 및 Siri에서 상태를 확인할 수 있어요.";
 "NLModelError" = "AI 검색 중 오류가 발생했어요.\n기본 키워드 검색으로 결과를 표시합니다.";
+
+/* Settings */
+"Settings" = "설정";
+"SettingsLanguage" = "언어";
+"SettingsSFSymbols" = "SF Symbols";
+"SettingsSFSymbolsVersion" = "SF Symbols 버전";
+"SettingsSFSymbolsVersionValue" = "5.1";
+"SettingsSFSymbolsCount" = "심볼 수";
+"SettingsAppInfo" = "앱 정보";
+"SettingsCurrentVersion" = "현재 버전";
+"SettingsChangeLanguage" = "언어 변경";

--- a/SF-Symbol-Finder/Resources/ko.lproj/Localizable.strings
+++ b/SF-Symbol-Finder/Resources/ko.lproj/Localizable.strings
@@ -32,3 +32,7 @@
 "NLSearchGuide" = "찾고 싶은 SF Symbol을 설명하면\n해당하는 심볼을 찾아드릴게요.";
 "NLSearching" = "심볼을 검색하는 중...";
 "NLNoResults" = "일치하는 심볼을 찾지 못했어요.\n다른 설명을 시도해 보세요.";
+"NLModelDeviceNotEligible" = "이 기기에서는 AI 검색을 사용할 수 없어요.\nApple Intelligence를 지원하는 기기에서 사용해 주세요.\n기본 키워드 검색으로 결과를 표시합니다.";
+"NLModelNotEnabled" = "AI 검색을 사용하려면 Apple Intelligence를 활성화해 주세요.\n설정 > Apple Intelligence 및 Siri에서 켤 수 있어요.\n기본 키워드 검색으로 결과를 표시합니다.";
+"NLModelNotReady" = "AI 모델을 준비하는 중이에요.\n잠시 후 다시 시도해 주세요.\n설정 > Apple Intelligence 및 Siri에서 상태를 확인할 수 있어요.";
+"NLModelError" = "AI 검색 중 오류가 발생했어요.\n기본 키워드 검색으로 결과를 표시합니다.";

--- a/SF-Symbol-Finder/Sources/Extensions/String+Extension.swift
+++ b/SF-Symbol-Finder/Sources/Extensions/String+Extension.swift
@@ -41,7 +41,7 @@ extension String {
 
     /* NaturalLanguageSearchView */
     static let searchModeDraw = "SearchModeDraw".localized()
-    static let searchModeDescribe = "SearchModeDescribe".localized()
+    static let searchModeBrowse = "SearchModeBrowse".localized()
   static let searchModeSearch = "searchModeSearch".localized()
     static let nlSearchPlaceholder = "NLSearchPlaceholder".localized()
     static let nlSearchGuide = "NLSearchGuide".localized()

--- a/SF-Symbol-Finder/Sources/Extensions/String+Extension.swift
+++ b/SF-Symbol-Finder/Sources/Extensions/String+Extension.swift
@@ -42,7 +42,7 @@ extension String {
     /* NaturalLanguageSearchView */
     static let searchModeDraw = "SearchModeDraw".localized()
     static let searchModeBrowse = "SearchModeBrowse".localized()
-  static let searchModeSearch = "searchModeSearch".localized()
+    static let searchModeDescribe = "SearchModeDescribe".localized()
     static let nlSearchPlaceholder = "NLSearchPlaceholder".localized()
     static let nlSearchGuide = "NLSearchGuide".localized()
     static let nlSearching = "NLSearching".localized()

--- a/SF-Symbol-Finder/Sources/Extensions/String+Extension.swift
+++ b/SF-Symbol-Finder/Sources/Extensions/String+Extension.swift
@@ -42,6 +42,7 @@ extension String {
     /* NaturalLanguageSearchView */
     static let searchModeDraw = "SearchModeDraw".localized()
     static let searchModeDescribe = "SearchModeDescribe".localized()
+  static let searchModeSearch = "searchModeSearch".localized()
     static let nlSearchPlaceholder = "NLSearchPlaceholder".localized()
     static let nlSearchGuide = "NLSearchGuide".localized()
     static let nlSearching = "NLSearching".localized()
@@ -50,6 +51,17 @@ extension String {
     static let nlModelNotEnabled = "NLModelNotEnabled".localized()
     static let nlModelNotReady = "NLModelNotReady".localized()
     static let nlModelError = "NLModelError".localized()
+
+    /* Settings */
+    static let settings = "Settings".localized()
+    static let settingsLanguage = "SettingsLanguage".localized()
+    static let settingsSFSymbols = "SettingsSFSymbols".localized()
+    static let settingsSFSymbolsVersion = "SettingsSFSymbolsVersion".localized()
+    static let settingsSFSymbolsVersionValue = "SettingsSFSymbolsVersionValue".localized()
+    static let settingsSFSymbolsCount = "SettingsSFSymbolsCount".localized()
+    static let settingsAppInfo = "SettingsAppInfo".localized()
+    static let settingsCurrentVersion = "SettingsCurrentVersion".localized()
+    static let settingsChangeLanguage = "SettingsChangeLanguage".localized()
 
 }
 

--- a/SF-Symbol-Finder/Sources/Extensions/String+Extension.swift
+++ b/SF-Symbol-Finder/Sources/Extensions/String+Extension.swift
@@ -46,6 +46,10 @@ extension String {
     static let nlSearchGuide = "NLSearchGuide".localized()
     static let nlSearching = "NLSearching".localized()
     static let nlNoResults = "NLNoResults".localized()
+    static let nlModelDeviceNotEligible = "NLModelDeviceNotEligible".localized()
+    static let nlModelNotEnabled = "NLModelNotEnabled".localized()
+    static let nlModelNotReady = "NLModelNotReady".localized()
+    static let nlModelError = "NLModelError".localized()
 
 }
 

--- a/SF-Symbol-Finder/Sources/Extensions/String+Extension.swift
+++ b/SF-Symbol-Finder/Sources/Extensions/String+Extension.swift
@@ -51,6 +51,7 @@ extension String {
     static let nlModelNotEnabled = "NLModelNotEnabled".localized()
     static let nlModelNotReady = "NLModelNotReady".localized()
     static let nlModelError = "NLModelError".localized()
+    static let nlModelDisclaimer = "NLModelDisclaimer".localized()
 
     /* Settings */
     static let settings = "Settings".localized()

--- a/SF-Symbol-Finder/Sources/Presentations/Main/ContentView.swift
+++ b/SF-Symbol-Finder/Sources/Presentations/Main/ContentView.swift
@@ -31,6 +31,8 @@ struct ContentView: View {
     @State var showErrorAlert = false
     @State var onAppeared = false
     @State private var searchMode: SearchMode = .describe
+    @State private var isSearchActive = false
+    @FocusState private var isSearchFieldFocused: Bool
     #if canImport(FoundationModels)
     @StateObject private var nlSearchViewModel = {
         if #available(iOS 26.0, *) {
@@ -46,35 +48,128 @@ struct ContentView: View {
     }
 
     var body: some View {
+        #if canImport(FoundationModels)
+        if #available(iOS 26.0, *) {
+            tabViewBody
+                .onAppear {
+                    if !onAppeared {
+                        canvasRepresentingView = CanvasRepresentingView(isClear: $isClear)
+                        onAppeared = true
+                    }
+                }
+        } else {
+            legacyBody
+        }
+        #else
+        legacyBody
+        #endif
+    }
+
+    #if canImport(FoundationModels)
+    @available(iOS 26.0, *)
+    private var tabViewBody: some View {
         ZStack {
             Color.neutral.ignoresSafeArea()
-            VStack(spacing: 0) {
-                searchModePicker
-                if searchMode == .draw {
-                    drawContent
+
+            Group {
+                if searchMode == .describe {
+                    NaturalLanguageSearchView(viewModel: nlSearchViewModel)
                 } else {
-                    describeContent
+                    drawContent
                 }
             }
 
             if showErrorAlert {
-                Color.black
-                    .opacity(0.8)
-                VStack(spacing: 10) {
-                    Image(systemName: .exclamationmarkWarninglightFill)
-                        .font(.title)
-                        .foregroundStyle(.white)
-                    Text(String.errorAlert)
-                        .font(.title2)
-                        .bold()
-                        .multilineTextAlignment(.center)
-                        .foregroundStyle(.white)
+                errorOverlay
+            }
+        }
+        .safeAreaInset(edge: .bottom) {
+            bottomBar
+                .padding(.horizontal)
+                .padding(.vertical, 8)
+        }
+        .animation(.spring(duration: 0.3), value: isSearchActive)
+    }
+
+    @available(iOS 26.0, *)
+    @ViewBuilder
+    private var bottomBar: some View {
+        HStack(spacing: 12) {
+            if !isSearchActive {
+                HStack(spacing: 0) {
+                    tabButton(mode: .describe, icon: "text.magnifyingglass")
+                    tabButton(mode: .draw, icon: "pencil.and.scribble")
                 }
-                .padding(30)
-                .background (
-                    RoundedRectangle(cornerRadius: 8)
-                        .foregroundStyle(.gray)
-                )
+                .padding(.horizontal, 6)
+                .padding(.vertical, 4)
+                .glassEffect(.regular, in: .capsule)
+                .transition(.move(edge: .leading).combined(with: .opacity))
+            }
+
+            if isSearchActive {
+                TextField(String.nlSearchPlaceholder, text: $nlSearchViewModel.searchText)
+                    .font(.subheadline)
+                    .focused($isSearchFieldFocused)
+                    .submitLabel(.search)
+                    .onSubmit { nlSearchViewModel.performSearch() }
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 8)
+                    .glassEffect(.regular, in: .capsule)
+                    .transition(.move(edge: .trailing).combined(with: .opacity))
+            }
+
+            Spacer()
+
+            if searchMode == .describe || isSearchActive {
+                Button {
+                    withAnimation(.spring(duration: 0.35, bounce: 0.15)) {
+                        isSearchActive.toggle()
+                        if isSearchActive {
+                            isSearchFieldFocused = true
+                        } else {
+                            isSearchFieldFocused = false
+                            nlSearchViewModel.searchText = ""
+                        }
+                    }
+                } label: {
+                    Image(systemName: isSearchActive ? "xmark" : "magnifyingglass")
+                        .font(.body.weight(.medium))
+                        .contentTransition(.symbolEffect(.replace))
+                        .padding(14)
+                }
+                .glassEffect(.regular.interactive(), in: .circle)
+            }
+        }
+    }
+
+    @available(iOS 26.0, *)
+    private func tabButton(mode: SearchMode, icon: String) -> some View {
+        Button {
+            withAnimation(.spring(duration: 0.25)) {
+                searchMode = mode
+            }
+        } label: {
+            VStack(spacing: 2) {
+                Image(systemName: icon)
+                    .font(.body)
+                Text(mode.title)
+                    .font(.caption2)
+            }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 6)
+            .glassEffect(searchMode == mode ? .regular : .identity, in: .capsule)
+        }
+        .opacity(searchMode == mode ? 1.0 : 0.5)
+    }
+    #endif
+
+    private var legacyBody: some View {
+        ZStack {
+            Color.neutral.ignoresSafeArea()
+            drawContent
+
+            if showErrorAlert {
+                errorOverlay
             }
         }
         .onAppear {
@@ -85,41 +180,40 @@ struct ContentView: View {
         }
     }
 
-    @ViewBuilder
-    private var searchModePicker: some View {
-        #if canImport(FoundationModels)
-        if #available(iOS 26.0, *) {
-            Picker("", selection: $searchMode) {
-                ForEach(SearchMode.allCases, id: \.self) { mode in
-                    Text(mode.title).tag(mode)
-                }
+    private var errorOverlay: some View {
+        ZStack {
+            Color.black.opacity(0.8)
+            VStack(spacing: 10) {
+                Image(systemName: .exclamationmarkWarninglightFill)
+                    .font(.title)
+                    .foregroundStyle(.white)
+                Text(String.errorAlert)
+                    .font(.title2)
+                    .bold()
+                    .multilineTextAlignment(.center)
+                    .foregroundStyle(.white)
             }
-            .pickerStyle(.segmented)
-            .padding(.horizontal, defaultPadding)
-            .padding(.top, 8)
+            .padding(30)
+            .background(
+                RoundedRectangle(cornerRadius: 8)
+                    .foregroundStyle(.gray)
+            )
         }
-        #endif
     }
 
     private var drawContent: some View {
-        Group {
-            if orientation.orientation == .portrait {
-                contentsInVStack
-            } else {
-                contentsInHStack
+        ZStack {
+            Color.neutral.ignoresSafeArea()
+            Group {
+                if orientation.orientation == .portrait {
+                    contentsInVStack
+                } else {
+                    contentsInHStack
+                }
             }
         }
     }
 
-    @ViewBuilder
-    private var describeContent: some View {
-        #if canImport(FoundationModels)
-        if #available(iOS 26.0, *) {
-            NaturalLanguageSearchView(viewModel: nlSearchViewModel)
-        }
-        #endif
-    }
-    
     private var contentsInHStack: some View {
         VStack {
             Spacer()
@@ -141,7 +235,7 @@ struct ContentView: View {
             Spacer()
         }
     }
-    
+
     private var contentsInVStack: some View {
         VStack {
             #if DEBUG

--- a/SF-Symbol-Finder/Sources/Presentations/Main/ContentView.swift
+++ b/SF-Symbol-Finder/Sources/Presentations/Main/ContentView.swift
@@ -9,248 +9,181 @@ import SwiftUI
 import CoreML
 import Vision
 
-enum SearchMode: String, CaseIterable {
-    case describe
-    case draw
-
-    var title: String {
-        switch self {
-        case .draw: return String.searchModeDraw
-        case .describe: return String.searchModeDescribe
-        }
-    }
-}
-
 struct ContentView: View {
-    @State var isClear = false
-    @State var canvasRepresentingView: CanvasRepresentingView?
-    @Environment(\.undoManager) var undoManager
-    @State var results = [Result]()
-    @State var isNavigate = false
-    @State var selectedLabel = ""
-    @State var showErrorAlert = false
-    @State var onAppeared = false
-    @State private var searchMode: SearchMode = .describe
-    @State private var isSearchActive = false
-    @FocusState private var isSearchFieldFocused: Bool
-    #if canImport(FoundationModels)
-    @StateObject private var nlSearchViewModel = {
-        if #available(iOS 26.0, *) {
-            return NaturalLanguageSearchViewModel()
-        } else {
-            fatalError()
-        }
-    }()
-    #endif
-    @EnvironmentObject var orientation: Orientation
-    var defaultPadding: CGFloat {
-        Constants.deviceModel == DeviceModel.iPad.rawValue ? 30 : 10
+  @State var isClear = false
+  @State var canvasRepresentingView: CanvasRepresentingView?
+  @Environment(\.undoManager) var undoManager
+  @State var results = [Result]()
+  @State var isNavigate = false
+  @State var selectedLabel = ""
+  @State var showErrorAlert = false
+  @State var onAppeared = false
+  @State private var searchMode: SearchMode = .draw
+  @State private var isSearchActive = false
+  @FocusState private var isSearchFieldFocused: Bool
+  @FocusState private var isSearchFocused: Bool
+#if canImport(FoundationModels)
+  @StateObject private var nlSearchViewModel = {
+    if #available(iOS 26.0, *) {
+      return NaturalLanguageSearchViewModel()
+    } else {
+      fatalError()
     }
-
-    var body: some View {
-        #if canImport(FoundationModels)
-        if #available(iOS 26.0, *) {
-            tabViewBody
-                .onAppear {
-                    if !onAppeared {
-                        canvasRepresentingView = CanvasRepresentingView(isClear: $isClear)
-                        onAppeared = true
-                    }
-                }
-        } else {
-            legacyBody
-        }
-        #else
-        legacyBody
-        #endif
-    }
-
-    #if canImport(FoundationModels)
-    @available(iOS 26.0, *)
-    private var tabViewBody: some View {
-        ZStack {
-            Color.neutral.ignoresSafeArea()
-
-            Group {
-                if searchMode == .describe {
-                    NaturalLanguageSearchView(viewModel: nlSearchViewModel)
-                } else {
-                    drawContent
-                }
-            }
-
-            if showErrorAlert {
-                errorOverlay
-            }
-        }
-        .safeAreaInset(edge: .bottom) {
-            bottomBar
-                .padding(.horizontal)
-                .padding(.vertical, 8)
-        }
-        .animation(.spring(duration: 0.3), value: isSearchActive)
-    }
-
-    @available(iOS 26.0, *)
-    @ViewBuilder
-    private var bottomBar: some View {
-        HStack(spacing: 12) {
-            if !isSearchActive {
-                HStack(spacing: 0) {
-                    tabButton(mode: .describe, icon: "text.magnifyingglass")
-                    tabButton(mode: .draw, icon: "pencil.and.scribble")
-                }
-                .padding(.horizontal, 6)
-                .padding(.vertical, 4)
-                .glassEffect(.regular, in: .capsule)
-                .transition(.move(edge: .leading).combined(with: .opacity))
-            }
-
-            if isSearchActive {
-                TextField(String.nlSearchPlaceholder, text: $nlSearchViewModel.searchText)
-                    .font(.subheadline)
-                    .focused($isSearchFieldFocused)
-                    .submitLabel(.search)
-                    .onSubmit { nlSearchViewModel.performSearch() }
-                    .padding(.horizontal, 12)
-                    .padding(.vertical, 8)
-                    .glassEffect(.regular, in: .capsule)
-                    .transition(.move(edge: .trailing).combined(with: .opacity))
-            }
-
-            Spacer()
-
-            if searchMode == .describe || isSearchActive {
-                Button {
-                    withAnimation(.spring(duration: 0.35, bounce: 0.15)) {
-                        isSearchActive.toggle()
-                        if isSearchActive {
-                            isSearchFieldFocused = true
-                        } else {
-                            isSearchFieldFocused = false
-                            nlSearchViewModel.searchText = ""
-                        }
-                    }
-                } label: {
-                    Image(systemName: isSearchActive ? "xmark" : "magnifyingglass")
-                        .font(.body.weight(.medium))
-                        .contentTransition(.symbolEffect(.replace))
-                        .padding(14)
-                }
-                .glassEffect(.regular.interactive(), in: .circle)
-            }
-        }
-    }
-
-    @available(iOS 26.0, *)
-    private func tabButton(mode: SearchMode, icon: String) -> some View {
-        Button {
-            withAnimation(.spring(duration: 0.25)) {
-                searchMode = mode
-            }
-        } label: {
-            VStack(spacing: 2) {
-                Image(systemName: icon)
-                    .font(.body)
-                Text(mode.title)
-                    .font(.caption2)
-            }
-            .padding(.horizontal, 14)
-            .padding(.vertical, 6)
-            .glassEffect(searchMode == mode ? .regular : .identity, in: .capsule)
-        }
-        .opacity(searchMode == mode ? 1.0 : 0.5)
-    }
-    #endif
-
-    private var legacyBody: some View {
-        ZStack {
-            Color.neutral.ignoresSafeArea()
-            drawContent
-
-            if showErrorAlert {
-                errorOverlay
-            }
-        }
+  }()
+#endif
+  @EnvironmentObject var orientation: Orientation
+  var defaultPadding: CGFloat {
+    Constants.deviceModel == DeviceModel.iPad.rawValue ? 30 : 10
+  }
+  
+  var body: some View {
+#if canImport(FoundationModels)
+    if #available(iOS 26.0, *) {
+      tabViewBody
         .onAppear {
-            if !onAppeared {
-                canvasRepresentingView = CanvasRepresentingView(isClear: $isClear)
-                onAppeared = true
-            }
+          if !onAppeared {
+            canvasRepresentingView = CanvasRepresentingView(isClear: $isClear)
+            onAppeared = true
+          }
         }
+    } else {
+      legacyBody
     }
-
-    private var errorOverlay: some View {
-        ZStack {
-            Color.black.opacity(0.8)
-            VStack(spacing: 10) {
-                Image(systemName: .exclamationmarkWarninglightFill)
-                    .font(.title)
-                    .foregroundStyle(.white)
-                Text(String.errorAlert)
-                    .font(.title2)
-                    .bold()
-                    .multilineTextAlignment(.center)
-                    .foregroundStyle(.white)
-            }
-            .padding(30)
-            .background(
-                RoundedRectangle(cornerRadius: 8)
-                    .foregroundStyle(.gray)
-            )
+#else
+    legacyBody
+#endif
+  }
+  
+#if canImport(FoundationModels)
+  @available(iOS 26.0, *)
+  private var tabViewBody: some View {
+    ZStack {
+      TabView(selection: $searchMode) {
+        Tab(String.searchModeDraw, systemImage: "pencil.and.scribble", value: .draw) {
+          drawContent
         }
-    }
-
-    private var drawContent: some View {
-        ZStack {
+        Tab(String.searchModeDescribe, systemImage: "square.grid.2x2", value: .describe) {
+          ZStack {
             Color.neutral.ignoresSafeArea()
-            Group {
-                if orientation.orientation == .portrait {
-                    contentsInVStack
-                } else {
-                    contentsInHStack
-                }
+            SFSymbolListView(keyword: "")
+          }
+        }
+        Tab(String.settings, systemImage: "gearshape", value: .settings) {
+          SettingsView()
+        }
+        Tab(value: .search, role: .search) {
+          NavigationStack {
+            ZStack {
+              Color.neutral.ignoresSafeArea()
+              NaturalLanguageSearchView(viewModel: nlSearchViewModel)
             }
-        }
-    }
-
-    private var contentsInHStack: some View {
-        VStack {
-            Spacer()
-            HStack {
-                #if DEBUG
-                canvasView
-                    .padding(.leading, defaultPadding)
-                    .frame(maxWidth: 1000, maxHeight: 1000)
-                #elseif RELEASE
-                canvasView
-                    .padding(.leading, defaultPadding)
-                    .frame(maxWidth: 500, maxHeight: 500)
-                #endif
-                resultView
-                    .padding(.trailing, defaultPadding)
-                    .frame(maxWidth: 500, maxHeight: 500)
+          }
+          .searchable(text: $nlSearchViewModel.searchText, placement: .automatic, prompt: String.nlSearchPlaceholder)
+          .searchFocused($isSearchFocused)
+          .onSubmit(of: .search) { nlSearchViewModel.performSearch() }
+          .onChange(of: searchMode) {
+            if searchMode == .search {
+              isSearchFocused = true
             }
-            .padding(.vertical, defaultPadding)
-            Spacer()
+          }
         }
-    }
+      }
 
-    private var contentsInVStack: some View {
-        VStack {
-            #if DEBUG
-            canvasView
-                .padding(.top, defaultPadding)
-                .frame(maxWidth: 1000, maxHeight: 1000)
-            #elseif RELEASE
-            canvasView
-                .padding(.top, defaultPadding)
-                .frame(maxWidth: 500, maxHeight: 500)
-            #endif
-            resultView
-                .padding(.bottom, defaultPadding)
-                .frame(maxWidth: 500, maxHeight: 800)
-        }
-        .padding(.horizontal, defaultPadding)
+      if showErrorAlert {
+        errorOverlay
+      }
     }
+  }
+#endif
+  
+  private var legacyBody: some View {
+    ZStack {
+      Color.neutral.ignoresSafeArea()
+      drawContent
+      
+      if showErrorAlert {
+        errorOverlay
+      }
+    }
+    .onAppear {
+      if !onAppeared {
+        canvasRepresentingView = CanvasRepresentingView(isClear: $isClear)
+        onAppeared = true
+      }
+    }
+  }
+  
+  private var errorOverlay: some View {
+    ZStack {
+      Color.black.opacity(0.8)
+      VStack(spacing: 10) {
+        Image(systemName: .exclamationmarkWarninglightFill)
+          .font(.title)
+          .foregroundStyle(.white)
+        Text(String.errorAlert)
+          .font(.title2)
+          .bold()
+          .multilineTextAlignment(.center)
+          .foregroundStyle(.white)
+      }
+      .padding(30)
+      .background(
+        RoundedRectangle(cornerRadius: 8)
+          .foregroundStyle(.gray)
+      )
+    }
+  }
+  
+  private var drawContent: some View {
+    ZStack {
+      Color.neutral.ignoresSafeArea()
+      Group {
+        if orientation.orientation == .portrait {
+          contentsInVStack
+        } else {
+          contentsInHStack
+        }
+      }
+    }
+  }
+  
+  private var contentsInHStack: some View {
+    VStack {
+      Spacer()
+      HStack {
+#if DEBUG
+        canvasView
+          .padding(.leading, defaultPadding)
+          .frame(maxWidth: 1000, maxHeight: 1000)
+#elseif RELEASE
+        canvasView
+          .padding(.leading, defaultPadding)
+          .frame(maxWidth: 500, maxHeight: 500)
+#endif
+        resultView
+          .padding(.trailing, defaultPadding)
+          .frame(maxWidth: 500, maxHeight: 500)
+      }
+      .padding(.vertical, defaultPadding)
+      Spacer()
+    }
+  }
+  
+  private var contentsInVStack: some View {
+    VStack {
+#if DEBUG
+      canvasView
+        .padding(.top, defaultPadding)
+        .frame(maxWidth: 1000, maxHeight: 1000)
+#elseif RELEASE
+      canvasView
+        .padding(.top, defaultPadding)
+        .frame(maxWidth: 500, maxHeight: 500)
+#endif
+      resultView
+        .padding(.bottom, defaultPadding)
+        .frame(maxWidth: 500, maxHeight: 800)
+    }
+    .padding(.horizontal, defaultPadding)
+  }
 }

--- a/SF-Symbol-Finder/Sources/Presentations/Main/ContentView.swift
+++ b/SF-Symbol-Finder/Sources/Presentations/Main/ContentView.swift
@@ -62,7 +62,7 @@ struct ContentView: View {
         Tab(String.searchModeDraw, systemImage: "pencil.and.scribble", value: .draw) {
           drawContent
         }
-        Tab(String.searchModeDescribe, systemImage: "square.grid.2x2", value: .describe) {
+        Tab(String.searchModeBrowse, systemImage: "square.grid.2x2", value: .browse) {
           ZStack {
             Color.neutral.ignoresSafeArea()
             SFSymbolListView(keyword: "")

--- a/SF-Symbol-Finder/Sources/Presentations/Main/ContentView.swift
+++ b/SF-Symbol-Finder/Sources/Presentations/Main/ContentView.swift
@@ -71,7 +71,7 @@ struct ContentView: View {
         Tab(String.settings, systemImage: "gearshape", value: .settings) {
           SettingsView()
         }
-        Tab(value: .search, role: .search) {
+        Tab(value: .describe, role: .search) {
           NavigationStack {
             ZStack {
               Color.neutral.ignoresSafeArea()
@@ -82,7 +82,7 @@ struct ContentView: View {
           .searchFocused($isSearchFocused)
           .onSubmit(of: .search) { nlSearchViewModel.performSearch() }
           .onChange(of: searchMode) {
-            if searchMode == .search {
+            if searchMode == .describe {
               isSearchFocused = true
             }
           }

--- a/SF-Symbol-Finder/Sources/Presentations/Main/SFSymbolListView.swift
+++ b/SF-Symbol-Finder/Sources/Presentations/Main/SFSymbolListView.swift
@@ -13,6 +13,9 @@ struct SFSymbolListView: View {
         keyword.replacingOccurrences(of: "_", with: ".")
     }
     private var systemNames: [String] {
+        if keywordReplaced.isEmpty {
+            return Constants.sfsymbols
+        }
         return Constants.sfsymbols.filter({ $0.contains(keywordReplaced)})
     }
     @State private var showClipboardAlert = false
@@ -58,31 +61,33 @@ struct SFSymbolListView: View {
                 .padding()
                 .padding(.top, 40)
             }
-            VStack {
-                ZStack {
-                    HStack {
-                        Spacer()
-                        Text(keywordReplaced)
-                            .foregroundStyle(Color.accentColor)
-                            .font(.body)
-                        Spacer()
-                    }
-                    HStack {
-                        Button {
-                            dismiss()
-                        } label: {
-                            Image(systemName: .chevronBackward)
-                                .font(.headline)
-                                .fontWeight(.bold)
+            if !keyword.isEmpty {
+                VStack {
+                    ZStack {
+                        HStack {
+                            Spacer()
+                            Text(keywordReplaced)
                                 .foregroundStyle(Color.accentColor)
+                                .font(.body)
+                            Spacer()
                         }
-                        .padding()
-                        Spacer()
+                        HStack {
+                            Button {
+                                dismiss()
+                            } label: {
+                                Image(systemName: .chevronBackward)
+                                    .font(.headline)
+                                    .fontWeight(.bold)
+                                    .foregroundStyle(Color.accentColor)
+                            }
+                            .padding()
+                            Spacer()
+                        }
                     }
+                    .background(Color.black.opacity(0.3))
+                    Spacer()
+                    Spacer()
                 }
-                .background(Color.black.opacity(0.3))
-                Spacer()
-                Spacer()
             }
             
             if showClipboardAlert {

--- a/SF-Symbol-Finder/Sources/Presentations/Main/SearchMode.swift
+++ b/SF-Symbol-Finder/Sources/Presentations/Main/SearchMode.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 enum SearchMode: String, CaseIterable {
-  case describe
+  case browse
   case draw
   case search
   case settings
@@ -16,7 +16,7 @@ enum SearchMode: String, CaseIterable {
   var title: String {
     switch self {
     case .draw: return String.searchModeDraw
-    case .describe: return String.searchModeDescribe
+    case .browse: return String.searchModeBrowse
     case .search: return String.searchModeSearch
     case .settings: return String.settings
     }

--- a/SF-Symbol-Finder/Sources/Presentations/Main/SearchMode.swift
+++ b/SF-Symbol-Finder/Sources/Presentations/Main/SearchMode.swift
@@ -1,0 +1,24 @@
+//
+//  SearchMode.swift
+//  SF-Symbol-Finder
+//
+//  Created by ZENA on 3/6/26.
+//
+
+import Foundation
+
+enum SearchMode: String, CaseIterable {
+  case describe
+  case draw
+  case search
+  case settings
+
+  var title: String {
+    switch self {
+    case .draw: return String.searchModeDraw
+    case .describe: return String.searchModeDescribe
+    case .search: return String.searchModeSearch
+    case .settings: return String.settings
+    }
+  }
+}

--- a/SF-Symbol-Finder/Sources/Presentations/Main/SearchMode.swift
+++ b/SF-Symbol-Finder/Sources/Presentations/Main/SearchMode.swift
@@ -10,14 +10,14 @@ import Foundation
 enum SearchMode: String, CaseIterable {
   case browse
   case draw
-  case search
+  case describe
   case settings
 
   var title: String {
     switch self {
     case .draw: return String.searchModeDraw
     case .browse: return String.searchModeBrowse
-    case .search: return String.searchModeSearch
+    case .describe: return String.searchModeDescribe
     case .settings: return String.settings
     }
   }

--- a/SF-Symbol-Finder/Sources/Presentations/NaturalLanguageSearch/NaturalLanguageSearchView.swift
+++ b/SF-Symbol-Finder/Sources/Presentations/NaturalLanguageSearch/NaturalLanguageSearchView.swift
@@ -106,6 +106,13 @@ struct NaturalLanguageSearchView: View {
                 .font(.body)
                 .foregroundStyle(.secondary)
                 .multilineTextAlignment(.center)
+            if !viewModel.hasSearched {
+                Text(String.nlModelDisclaimer)
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+                    .multilineTextAlignment(.center)
+                    .padding(.top, 8)
+            }
             Spacer()
         } else {
             modelStatusBanner

--- a/SF-Symbol-Finder/Sources/Presentations/NaturalLanguageSearch/NaturalLanguageSearchView.swift
+++ b/SF-Symbol-Finder/Sources/Presentations/NaturalLanguageSearch/NaturalLanguageSearchView.swift
@@ -14,6 +14,7 @@ final class NaturalLanguageSearchViewModel: ObservableObject {
     @Published var searchResults: [String] = []
     @Published var isSearching = false
     @Published var hasSearched = false
+    @Published var modelStatus: ModelStatus?
 
     private let service = FoundationModelService()
 
@@ -24,16 +25,19 @@ final class NaturalLanguageSearchViewModel: ObservableObject {
         isSearching = true
         hasSearched = true
         searchResults = []
+        modelStatus = nil
 
         Task {
             do {
-                let results = try await service.searchSymbols(for: query)
+                let result = try await service.searchSymbols(for: query)
                 await MainActor.run {
-                    self.searchResults = results
+                    self.searchResults = result.symbols
+                    self.modelStatus = result.usedFallback ? result.modelStatus : nil
                     self.isSearching = false
                 }
             } catch {
                 await MainActor.run {
+                    self.modelStatus = .modelError
                     self.isSearching = false
                 }
             }
@@ -46,17 +50,12 @@ struct NaturalLanguageSearchView: View {
     @ObservedObject var viewModel: NaturalLanguageSearchViewModel
     @State private var showClipboardAlert = false
     @State private var selectedSymbol: String?
-    @FocusState private var isTextFieldFocused: Bool
 
     var body: some View {
         ZStack {
-            Color.neutral.ignoresSafeArea()
-
-            VStack(spacing: 16) {
-                searchBar
+            VStack(spacing: 0) {
                 resultContent
             }
-            .padding()
 
             if showClipboardAlert {
                 clipboardAlert
@@ -64,53 +63,29 @@ struct NaturalLanguageSearchView: View {
         }
     }
 
-    private var searchBar: some View {
-        HStack(spacing: 12) {
-            HStack(spacing: 8) {
-                Image(systemName: "magnifyingglass")
-                    .foregroundStyle(.gray)
-                    .font(.subheadline)
-                TextField("", text: $viewModel.searchText, prompt: Text(String.nlSearchPlaceholder).foregroundColor(.white.opacity(0.5)))
-                    .font(.subheadline)
-                    .foregroundStyle(.white)
-                    .focused($isTextFieldFocused)
-                    .submitLabel(.search)
-                    .onSubmit { viewModel.performSearch() }
-                if !viewModel.searchText.isEmpty {
-                    Button {
-                        viewModel.searchText = ""
-                        viewModel.searchResults = []
-                        viewModel.hasSearched = false
-                        isTextFieldFocused = true
-                    } label: {
-                        Image(systemName: "xmark.circle.fill")
-                            .foregroundStyle(.gray)
-                            .font(.subheadline)
-                    }
-                }
+    @ViewBuilder
+    private var modelStatusBanner: some View {
+        if let status = viewModel.modelStatus {
+            HStack(alignment: .top, spacing: 10) {
+                Image(systemName: status == .modelNotReady ? "arrow.down.circle" : "exclamationmark.triangle.fill")
+                    .font(.body)
+                    .foregroundStyle(Color(red: 1.0, green: 0.85, blue: 0.7))
+                Text(status.localizedMessage)
+                    .font(.caption)
+                    .foregroundStyle(Color.white.opacity(0.85))
+                    .multilineTextAlignment(.leading)
+                Spacer()
             }
-            .padding(.horizontal, 12)
-            .padding(.vertical, 10)
-            .frame(minHeight: 44)
+            .padding(12)
             .background(
-                RoundedRectangle(cornerRadius: 12)
-                    .fill(Color.white.opacity(0.08))
+                RoundedRectangle(cornerRadius: 10)
+                    .fill(Color.orange.opacity(0.1))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 10)
+                            .stroke(Color.orange.opacity(0.3), lineWidth: 0.5)
+                    )
             )
-            .overlay(
-                RoundedRectangle(cornerRadius: 12)
-                    .stroke(Color.gray.opacity(0.3), lineWidth: 0.5)
-            )
-
-            Button {
-                isTextFieldFocused = false
-                viewModel.performSearch()
-            } label: {
-                Image(systemName: "arrow.right.circle.fill")
-                    .font(.title2)
-                    .foregroundStyle(Color.accentColor)
-            }
-            .disabled(viewModel.searchText.trimmingCharacters(in: .whitespaces).isEmpty || viewModel.isSearching)
-            .opacity(viewModel.searchText.trimmingCharacters(in: .whitespaces).isEmpty ? 0.4 : 1.0)
+            .padding(.horizontal)
         }
     }
 
@@ -119,75 +94,65 @@ struct NaturalLanguageSearchView: View {
         if viewModel.isSearching {
             Spacer()
             ProgressView()
-                .tint(.white)
             Text(String.nlSearching)
-                .foregroundStyle(.gray)
+                .foregroundStyle(.secondary)
             Spacer()
         } else if viewModel.searchResults.isEmpty {
+            if viewModel.modelStatus != nil {
+                modelStatusBanner
+            }
             Spacer()
             Text(viewModel.hasSearched ? String.nlNoResults : String.nlSearchGuide)
                 .font(.body)
-                .foregroundStyle(.gray)
+                .foregroundStyle(.secondary)
                 .multilineTextAlignment(.center)
             Spacer()
         } else {
-            Text(String.guideOnClickToCopy)
-                .font(.headline)
-                .foregroundStyle(Color.accentColor)
+            modelStatusBanner
 
-            HStack(spacing: 0) {
-                ScrollView {
-                    LazyVGrid(columns: [GridItem()]) {
-                        ForEach(viewModel.searchResults, id: \.self) { symbolName in
-                            ZStack {
-                                Rectangle()
-                                    .stroke(Color.accentColor, lineWidth: 0.5)
-                                    .background(selectedSymbol == symbolName ? Color.accentColor.opacity(0.3) : Color.neutral)
-                                HStack(spacing: 10) {
-                                    Image(systemName: symbolName)
-                                        .font(.largeTitle)
-                                        .padding()
-                                        .foregroundStyle(.white)
-                                        .frame(width: 80)
-                                    Text(symbolName)
-                                        .font(.subheadline)
-                                        .foregroundStyle(.white)
-                                    Spacer()
-                                }
-                            }
-                            .onTapGesture {
-                                UIPasteboard.general.string = symbolName
-                                selectedSymbol = symbolName
-                                showClipboardAlert = true
-                                DispatchQueue.main.asyncAfter(deadline: .now() + 0.7) {
-                                    selectedSymbol = nil
-                                }
+            ScrollView {
+                LazyVStack(spacing: 0) {
+                    ForEach(viewModel.searchResults, id: \.self) { symbolName in
+                        HStack(spacing: 14) {
+                            Image(systemName: symbolName)
+                                .font(.title2)
+                                .frame(width: 40, height: 40)
+                            Text(symbolName)
+                                .font(.subheadline)
+                            Spacer()
+                        }
+                        .padding(.horizontal)
+                        .padding(.vertical, 10)
+                        .background(selectedSymbol == symbolName ? Color.accentColor.opacity(0.2) : Color.clear)
+                        .contentShape(Rectangle())
+                        .onTapGesture {
+                            UIPasteboard.general.string = symbolName
+                            selectedSymbol = symbolName
+                            showClipboardAlert = true
+                            DispatchQueue.main.asyncAfter(deadline: .now() + 0.7) {
+                                selectedSymbol = nil
                             }
                         }
+                        Divider()
+                            .padding(.leading, 68)
                     }
-                    .padding(.trailing, 4)
                 }
-                .scrollDismissesKeyboard(.interactively)
             }
+            .scrollDismissesKeyboard(.interactively)
         }
     }
 
     private var clipboardAlert: some View {
         ZStack {
-            Color.black.opacity(0.7).ignoresSafeArea()
+            Color.black.opacity(0.5).ignoresSafeArea()
             HStack(spacing: 10) {
                 Image(systemName: .docOnClipboard)
                     .font(.title3)
-                    .foregroundStyle(.white)
                 Text(String.alertCopied)
                     .font(.title3)
-                    .foregroundStyle(.white)
             }
             .padding()
-            .background(
-                RoundedRectangle(cornerRadius: 8)
-                    .foregroundColor(.gray.opacity(0.5))
-            )
+            .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 12))
             .onAppear {
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.7) {
                     showClipboardAlert = false

--- a/SF-Symbol-Finder/Sources/Presentations/Settings/SettingsView.swift
+++ b/SF-Symbol-Finder/Sources/Presentations/Settings/SettingsView.swift
@@ -1,0 +1,103 @@
+//
+//  SettingsView.swift
+//  SF-Symbol-Finder
+//
+//  Created by ZENA on 2026/03/09.
+//
+
+import SwiftUI
+
+struct SettingsView: View {
+
+  var body: some View {
+    ZStack {
+      Color.neutral.ignoresSafeArea()
+      List {
+        languageSection
+        sfSymbolsSection
+        appInfoSection
+      }
+      .scrollContentBackground(.hidden)
+    }
+  }
+
+  // MARK: - Language
+  private var languageSection: some View {
+    Section(header: Text(String.settingsLanguage)) {
+      Button {
+        if let url = URL(string: UIApplication.openSettingsURLString) {
+          UIApplication.shared.open(url)
+        }
+      } label: {
+        HStack {
+          Text(String.settingsChangeLanguage)
+            .foregroundStyle(.primary)
+          Spacer()
+          Text(AppLanguage.current.displayName)
+            .foregroundStyle(.secondary)
+          Image(systemName: "chevron.right")
+            .font(.caption)
+            .foregroundStyle(.secondary)
+        }
+      }
+    }
+  }
+
+  // MARK: - SF Symbols
+  private var sfSymbolsSection: some View {
+    Section(header: Text(String.settingsSFSymbols)) {
+      HStack {
+        Text(String.settingsSFSymbolsVersion)
+        Spacer()
+        Text(String.settingsSFSymbolsVersionValue)
+          .foregroundStyle(.secondary)
+      }
+      HStack {
+        Text(String.settingsSFSymbolsCount)
+        Spacer()
+        Text("\(Constants.sfsymbols.count)")
+          .foregroundStyle(.secondary)
+      }
+    }
+  }
+
+  // MARK: - App Info
+  private var appInfoSection: some View {
+    Section(header: Text(String.settingsAppInfo)) {
+      HStack {
+        Text(String.settingsCurrentVersion)
+        Spacer()
+        Text(Bundle.main.appVersion)
+          .foregroundStyle(.secondary)
+      }
+    }
+  }
+}
+
+// MARK: - Bundle Extension
+extension Bundle {
+  var appVersion: String {
+    infoDictionary?["CFBundleShortVersionString"] as? String ?? "-"
+  }
+}
+
+// MARK: - App Language
+enum AppLanguage: String, CaseIterable {
+  case korean = "ko"
+  case english = "en"
+
+  var displayName: String {
+    switch self {
+    case .korean: return "한국어"
+    case .english: return "English"
+    }
+  }
+
+  static var current: AppLanguage {
+    let preferred = Locale.preferredLanguages.first ?? "en"
+    if preferred.hasPrefix("ko") {
+      return .korean
+    }
+    return .english
+  }
+}

--- a/SF-Symbol-Finder/Sources/Services/FoundationModelService.swift
+++ b/SF-Symbol-Finder/Sources/Services/FoundationModelService.swift
@@ -9,6 +9,37 @@
 import FoundationModels
 
 @available(iOS 26.0, *)
+enum ModelStatus {
+    case available
+    case deviceNotEligible
+    case appleIntelligenceNotEnabled
+    case modelNotReady
+    case modelError
+
+    var localizedMessage: String {
+        switch self {
+        case .available:
+            return ""
+        case .deviceNotEligible:
+            return .nlModelDeviceNotEligible
+        case .appleIntelligenceNotEnabled:
+            return .nlModelNotEnabled
+        case .modelNotReady:
+            return .nlModelNotReady
+        case .modelError:
+            return .nlModelError
+        }
+    }
+}
+
+@available(iOS 26.0, *)
+struct SymbolSearchResult {
+    let symbols: [String]
+    let modelStatus: ModelStatus
+    let usedFallback: Bool
+}
+
+@available(iOS 26.0, *)
 final class FoundationModelService {
 
     private let session: LanguageModelSession
@@ -73,18 +104,37 @@ final class FoundationModelService {
         self.session = LanguageModelSession(instructions: instructions)
     }
 
-    func searchSymbols(for description: String) async throws -> [String] {
+    func searchSymbols(for description: String) async throws -> SymbolSearchResult {
         // Foundation Model로 키워드 추출 시도
         var keywords: [String] = []
+        var modelStatus: ModelStatus = .available
+        var usedFallback = false
 
-        if SystemLanguageModel.default.isAvailable {
+        switch SystemLanguageModel.default.availability {
+        case .available:
             do {
                 let prompt = "What SF Symbol name keywords are related to this description? Think broadly about all symbols that could match: \"\(description)\""
                 let response = try await session.respond(to: prompt, generating: SymbolKeywords.self)
                 keywords = response.content.keywords.map { $0.lowercased() }
             } catch {
-                // 모델 실패 시 폴백으로 진행
+                modelStatus = .modelError
+                usedFallback = true
             }
+        case .unavailable(let reason):
+            usedFallback = true
+            switch reason {
+            case .deviceNotEligible:
+                modelStatus = .deviceNotEligible
+            case .appleIntelligenceNotEnabled:
+                modelStatus = .appleIntelligenceNotEnabled
+            case .modelNotReady:
+                modelStatus = .modelNotReady
+            @unknown default:
+                modelStatus = .modelError
+            }
+        @unknown default:
+            modelStatus = .modelError
+            usedFallback = true
         }
 
         // 모델 미사용/실패 시 직접 키워드 분리
@@ -103,7 +153,7 @@ final class FoundationModelService {
             matchedSymbols = matchSymbols(with: singleChars)
         }
 
-        return matchedSymbols
+        return SymbolSearchResult(symbols: matchedSymbols, modelStatus: modelStatus, usedFallback: usedFallback)
     }
 
     private func matchSymbols(with keywords: [String]) -> [String] {

--- a/SF-Symbol-Finder/Sources/Utils/Constants.swift
+++ b/SF-Symbol-Finder/Sources/Utils/Constants.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct Constants {
     static let deviceModel = UIDevice.current.model
+
     static let sfsymbols = [
         "clock.badge.questionmark.fill",
         "chevron.forward.2",


### PR DESCRIPTION
## Summary     
resolve #8, #10                                                                                                                                                                                                                                    
  - Foundation Model 상태별 에러 메시지 표시 (기기 미지원, AI 비활성화, 모델 준비 중, 오류)                                                                                                                                                          
  - 상단 세그먼트 탭 → iOS 26 기본 TabView (리퀴드 글래스) 전환                                                                                                                                                                                      
  - Tab(role: .search)로 네이티브 검색 탭 통합 (.searchable + 자동 포커스)                                                                                                                                                                           
  - 설정 탭 신설: 언어 변경, SF Symbols 정보, 앱 버전                                                                                                                                                                                                
  - 전체(browse) 탭에서 SF Symbols 전체 목록 표시                                                                                                                                                                                                    
  - 검색 탭에 Foundation Model 면책 문구 추가                                                                                                                                                                                                        
  - 탭 순서: 그리기 → 전체 → 설정 → 검색                                                                                                                                                                                                             
                                                                                                                                                                                                                                                     
  ## Test plan                                                                                                                                                                                                                                       
  - [ ] iOS 26 시뮬레이터/기기에서 TabView 정상 표시 확인                                                                                                                                                                                            
  - [ ] 검색 탭 진입 시 키보드 자동 포커스 확인                                                                                                                                                                                                      
  - [ ] Foundation Model 미지원 기기에서 에러 배너 표시 확인                                                                                                                                                                                         
  - [ ] 설정 탭 > 언어 변경 버튼이 시스템 설정으로 이동하는지 확인                                                                                                                                                                                   
  - [ ] 전체 탭에서 SF Symbols 목록 정상 표시 확인                                                                                                                                                                                                   
  - [ ] iOS 16 이하에서 legacyBody 정상 동작 확인   