### PR TITLE
[release] v2.0.0

### DIFF
--- a/SF-Symbol-Finder.xcodeproj/project.pbxproj
+++ b/SF-Symbol-Finder.xcodeproj/project.pbxproj
@@ -384,7 +384,7 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 1.0.1;
+				MARKETING_VERSION = 2.0.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -443,7 +443,7 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 1.0.1;
+				MARKETING_VERSION = 2.0.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				SDKROOT = iphoneos;
@@ -475,7 +475,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.1;
+				MARKETING_VERSION = 2.0.0;
 				NEW_SETTING = "";
 				PRODUCT_BUNDLE_IDENTIFIER = "me.zena.SF-Symbol-Finder";
 				PRODUCT_NAME = "SF Symbols Finder";
@@ -512,7 +512,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.1;
+				MARKETING_VERSION = 2.0.0;
 				NEW_SETTING = "";
 				PRODUCT_BUNDLE_IDENTIFIER = "me.zena.SF-Symbol-Finder";
 				PRODUCT_NAME = "SF Symbols Finder";


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                                                                         
  - 앱 버전 2.0.0 릴리즈                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                     
  ### 주요 변경사항                                                                                                                                                                                                                                  
  - Foundation Model 상태별 에러 메시지 표시 (기기 미지원, AI 비활성화, 모델 준비 중, 오류)                                                                                                                                                          
  - iOS 26 기본 TabView (리퀴드 글래스) 적용                                                                                                                                                                                                         
  - Tab(role: .search)로 네이티브 검색 탭 통합                                                                                                                                                                                                       
  - 설정 탭 신설: 언어 변경, SF Symbols 정보, 앱 버전                                                                                                                                                                                                
  - 전체(browse) 탭에서 SF Symbols 전체 목록 표시                                                                                                                                                                                                    
  - 검색 탭에 Foundation Model 면책 문구 추가                                                                                                                                                                                                        
  - 탭 순서: 그리기 → 전체 → 설정 → 검색                                                                                                                                                                                                             
                                                                                                                                                                                                                                                     
  ## Test plan                                                                                                                                                                                                                                       
  - [ ] iOS 26 기기/시뮬레이터에서 전체 기능 동작 확인                                                                                                                                                                                               
  - [ ] 설정 탭 앱 버전 2.0.0 표시 확인                                                                                                                                                                                                              
  - [ ] iOS 16 이하 legacyBody 정상 동작 확인   