### PR TITLE
[feat][#14] NL 검색 탭에 AI Thinking 메시지 박스 추가

### DIFF
--- a/SF-Symbol-Finder/Resources/en.lproj/Localizable.strings
+++ b/SF-Symbol-Finder/Resources/en.lproj/Localizable.strings
@@ -38,6 +38,11 @@
 "NLModelNotReady" = "The AI model is being prepared.\nPlease try again shortly.\nYou can check the status in Settings > Apple Intelligence & Siri.";
 "NLModelError" = "An error occurred during AI search.\nShowing results from basic keyword search.";
 "NLModelDisclaimer" = "Powered by Apple's Foundation Model.\nResults may not always be accurate.";
+"NLThinkingAnalyzing" = "Analyzing \"%@\"...";
+"NLThinkingSearching" = "Searching for matching symbols...";
+"NLThinkingFinding" = "Finding the best matches...";
+"NLThinkingDone" = "Found %d symbols";
+"NLThinkingNoResults" = "Couldn't find matching symbols";
 
 /* Settings */
 "Settings" = "Settings";

--- a/SF-Symbol-Finder/Resources/ko.lproj/Localizable.strings
+++ b/SF-Symbol-Finder/Resources/ko.lproj/Localizable.strings
@@ -38,6 +38,11 @@
 "NLModelNotReady" = "AI 모델을 준비하는 중이에요.\n잠시 후 다시 시도해 주세요.\n설정 > Apple Intelligence 및 Siri에서 상태를 확인할 수 있어요.";
 "NLModelError" = "AI 검색 중 오류가 발생했어요.\n기본 키워드 검색으로 결과를 표시합니다.";
 "NLModelDisclaimer" = "Apple의 Foundation Model을 사용합니다.\n결과가 정확하지 않을 수 있습니다.";
+"NLThinkingAnalyzing" = "\"%@\" 분석 중...";
+"NLThinkingSearching" = "일치하는 심볼 검색 중...";
+"NLThinkingFinding" = "최적의 결과를 찾는 중...";
+"NLThinkingDone" = "%d개의 심볼을 찾았어요";
+"NLThinkingNoResults" = "일치하는 심볼을 찾지 못했어요";
 
 /* Settings */
 "Settings" = "설정";

--- a/SF-Symbol-Finder/Sources/Extensions/String+Extension.swift
+++ b/SF-Symbol-Finder/Sources/Extensions/String+Extension.swift
@@ -52,6 +52,11 @@ extension String {
     static let nlModelNotReady = "NLModelNotReady".localized()
     static let nlModelError = "NLModelError".localized()
     static let nlModelDisclaimer = "NLModelDisclaimer".localized()
+    static let nlThinkingAnalyzing = "NLThinkingAnalyzing"
+    static let nlThinkingSearching = "NLThinkingSearching".localized()
+    static let nlThinkingFinding = "NLThinkingFinding".localized()
+    static let nlThinkingDone = "NLThinkingDone"
+    static let nlThinkingNoResults = "NLThinkingNoResults".localized()
 
     /* Settings */
     static let settings = "Settings".localized()

--- a/SF-Symbol-Finder/Sources/Presentations/Main/ContentView.swift
+++ b/SF-Symbol-Finder/Sources/Presentations/Main/ContentView.swift
@@ -81,6 +81,11 @@ struct ContentView: View {
           .searchable(text: $nlSearchViewModel.searchText, placement: .automatic, prompt: String.nlSearchPlaceholder)
           .searchFocused($isSearchFocused)
           .onSubmit(of: .search) { nlSearchViewModel.performSearch() }
+          .onChange(of: nlSearchViewModel.searchText) {
+            if nlSearchViewModel.searchText.isEmpty {
+              nlSearchViewModel.resetState()
+            }
+          }
           .onChange(of: searchMode) {
             if searchMode == .describe {
               isSearchFocused = true

--- a/SF-Symbol-Finder/Sources/Presentations/NaturalLanguageSearch/NaturalLanguageSearchView.swift
+++ b/SF-Symbol-Finder/Sources/Presentations/NaturalLanguageSearch/NaturalLanguageSearchView.swift
@@ -9,14 +9,27 @@
 import SwiftUI
 
 @available(iOS 26.0, *)
+enum ThinkingPhase: Equatable {
+    case idle
+    case analyzing
+    case searching
+    case finding
+    case done(count: Int)
+    case noResults
+}
+
+@available(iOS 26.0, *)
 final class NaturalLanguageSearchViewModel: ObservableObject {
     @Published var searchText = ""
     @Published var searchResults: [String] = []
     @Published var isSearching = false
     @Published var hasSearched = false
     @Published var modelStatus: ModelStatus?
+    @Published var thinkingPhase: ThinkingPhase = .idle
+    @Published var thinkingMessage: String = ""
 
     private let service = FoundationModelService()
+    private var thinkingTask: Task<Void, Never>?
 
     func performSearch() {
         let query = searchText.trimmingCharacters(in: .whitespaces)
@@ -26,6 +39,7 @@ final class NaturalLanguageSearchViewModel: ObservableObject {
         hasSearched = true
         searchResults = []
         modelStatus = nil
+        startThinking(query: query)
 
         Task {
             do {
@@ -34,13 +48,45 @@ final class NaturalLanguageSearchViewModel: ObservableObject {
                     self.searchResults = result.symbols
                     self.modelStatus = result.usedFallback ? result.modelStatus : nil
                     self.isSearching = false
+                    self.finishThinking(count: result.symbols.count)
                 }
             } catch {
                 await MainActor.run {
                     self.modelStatus = .modelError
                     self.isSearching = false
+                    self.finishThinking(count: 0)
                 }
             }
+        }
+    }
+
+    private func startThinking(query: String) {
+        thinkingTask?.cancel()
+        thinkingPhase = .analyzing
+        thinkingMessage = String.nlThinkingAnalyzing.localized(with: query)
+
+        thinkingTask = Task { @MainActor in
+            try? await Task.sleep(for: .seconds(1.2))
+            guard !Task.isCancelled else { return }
+            thinkingPhase = .searching
+            thinkingMessage = String.nlThinkingSearching
+
+            try? await Task.sleep(for: .seconds(1.5))
+            guard !Task.isCancelled else { return }
+            thinkingPhase = .finding
+            thinkingMessage = String.nlThinkingFinding
+        }
+    }
+
+    private func finishThinking(count: Int) {
+        thinkingTask?.cancel()
+        thinkingTask = nil
+        if count > 0 {
+            thinkingPhase = .done(count: count)
+            thinkingMessage = String.nlThinkingDone.localized(with: count)
+        } else {
+            thinkingPhase = .noResults
+            thinkingMessage = String.nlThinkingNoResults
         }
     }
 }
@@ -90,14 +136,59 @@ struct NaturalLanguageSearchView: View {
     }
 
     @ViewBuilder
+    private var thinkingMessageBox: some View {
+        if viewModel.thinkingPhase != .idle {
+            VStack(alignment: .leading, spacing: 6) {
+                HStack(spacing: 6) {
+                    Image(systemName: "sparkles")
+                        .font(.caption)
+                        .foregroundStyle(Color.indigo)
+                        .symbolEffect(.pulse, isActive: viewModel.isSearching)
+                    Text("AI")
+                        .font(.caption.bold())
+                        .foregroundStyle(Color.indigo)
+                }
+                HStack(spacing: 4) {
+                    Text(viewModel.thinkingMessage)
+                        .font(.callout)
+                        .foregroundStyle(Color.white.opacity(0.85))
+                        .contentTransition(.numericText())
+                        .animation(.easeInOut(duration: 0.3), value: viewModel.thinkingMessage)
+                    if viewModel.isSearching {
+                        ThinkingIndicatorView()
+                    }
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(12)
+            .background(
+                RoundedRectangle(cornerRadius: 10)
+                    .fill(Color.indigo.opacity(0.1))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 10)
+                            .stroke(Color.indigo.opacity(0.3), lineWidth: 0.5)
+                    )
+            )
+            .padding(.horizontal)
+            .padding(.top, 8)
+            .transition(.asymmetric(
+                insertion: .opacity.combined(with: .move(edge: .top)),
+                removal: .opacity
+            ))
+        }
+    }
+
+    @ViewBuilder
     private var resultContent: some View {
         if viewModel.isSearching {
+            thinkingMessageBox
             Spacer()
             ProgressView()
-            Text(String.nlSearching)
-                .foregroundStyle(.secondary)
             Spacer()
         } else if viewModel.searchResults.isEmpty {
+            if viewModel.hasSearched {
+                thinkingMessageBox
+            }
             if viewModel.modelStatus != nil {
                 modelStatusBanner
             }
@@ -115,6 +206,7 @@ struct NaturalLanguageSearchView: View {
             }
             Spacer()
         } else {
+            thinkingMessageBox
             modelStatusBanner
 
             ScrollView {
@@ -166,6 +258,24 @@ struct NaturalLanguageSearchView: View {
                 }
             }
         }
+    }
+}
+
+@available(iOS 26.0, *)
+private struct ThinkingIndicatorView: View {
+    private static let symbols = ["·", "✢", "✳\u{FE0E}", "✶", "✦", "✧"]
+    @State private var index = 0
+    private let timer = Timer.publish(every: 0.35, on: .main, in: .common).autoconnect()
+
+    var body: some View {
+        Text(Self.symbols[index])
+            .font(.callout)
+            .foregroundStyle(Color.indigo)
+            .contentTransition(.interpolate)
+            .animation(.easeInOut(duration: 0.25), value: index)
+            .onReceive(timer) { _ in
+                index = (index + 1) % Self.symbols.count
+            }
     }
 }
 #endif

--- a/SF-Symbol-Finder/Sources/Presentations/NaturalLanguageSearch/NaturalLanguageSearchView.swift
+++ b/SF-Symbol-Finder/Sources/Presentations/NaturalLanguageSearch/NaturalLanguageSearchView.swift
@@ -142,11 +142,11 @@ struct NaturalLanguageSearchView: View {
                 HStack(spacing: 6) {
                     Image(systemName: "sparkles")
                         .font(.caption)
-                        .foregroundStyle(Color.indigo)
+                        .foregroundStyle(Color.accentColor)
                         .symbolEffect(.pulse, isActive: viewModel.isSearching)
                     Text("AI")
                         .font(.caption.bold())
-                        .foregroundStyle(Color.indigo)
+                        .foregroundStyle(Color.accentColor)
                 }
                 HStack(spacing: 4) {
                     Text(viewModel.thinkingMessage)
@@ -163,10 +163,10 @@ struct NaturalLanguageSearchView: View {
             .padding(12)
             .background(
                 RoundedRectangle(cornerRadius: 10)
-                    .fill(Color.indigo.opacity(0.1))
+                    .fill(Color.accentColor.opacity(0.1))
                     .overlay(
                         RoundedRectangle(cornerRadius: 10)
-                            .stroke(Color.indigo.opacity(0.3), lineWidth: 0.5)
+                            .stroke(Color.accentColor.opacity(0.3), lineWidth: 0.5)
                     )
             )
             .padding(.horizontal)
@@ -270,7 +270,7 @@ private struct ThinkingIndicatorView: View {
     var body: some View {
         Text(Self.symbols[index])
             .font(.callout)
-            .foregroundStyle(Color.indigo)
+            .foregroundStyle(Color.accentColor)
             .contentTransition(.interpolate)
             .animation(.easeInOut(duration: 0.25), value: index)
             .onReceive(timer) { _ in

--- a/SF-Symbol-Finder/Sources/Presentations/NaturalLanguageSearch/NaturalLanguageSearchView.swift
+++ b/SF-Symbol-Finder/Sources/Presentations/NaturalLanguageSearch/NaturalLanguageSearchView.swift
@@ -139,12 +139,12 @@ struct NaturalLanguageSearchView: View {
     private var thinkingMessageBox: some View {
         if viewModel.thinkingPhase != .idle {
             VStack(alignment: .leading, spacing: 6) {
-                HStack(spacing: 6) {
-                    Image(systemName: "sparkles")
+                HStack(spacing: 5) {
+                    Image(systemName: "apple.intelligence")
                         .font(.caption)
                         .foregroundStyle(Color.accentColor)
                         .symbolEffect(.pulse, isActive: viewModel.isSearching)
-                    Text("AI")
+                    Text("Apple Intelligence")
                         .font(.caption.bold())
                         .foregroundStyle(Color.accentColor)
                 }

--- a/SF-Symbol-Finder/Sources/Presentations/NaturalLanguageSearch/NaturalLanguageSearchView.swift
+++ b/SF-Symbol-Finder/Sources/Presentations/NaturalLanguageSearch/NaturalLanguageSearchView.swift
@@ -60,6 +60,17 @@ final class NaturalLanguageSearchViewModel: ObservableObject {
         }
     }
 
+    func resetState() {
+        thinkingTask?.cancel()
+        thinkingTask = nil
+        searchResults = []
+        isSearching = false
+        hasSearched = false
+        modelStatus = nil
+        thinkingPhase = .idle
+        thinkingMessage = ""
+    }
+
     private func startThinking(query: String) {
         thinkingTask?.cancel()
         thinkingPhase = .analyzing

--- a/SF-Symbol-Finder/Sources/Presentations/NaturalLanguageSearch/NaturalLanguageSearchView.swift
+++ b/SF-Symbol-Finder/Sources/Presentations/NaturalLanguageSearch/NaturalLanguageSearchView.swift
@@ -142,7 +142,7 @@ struct NaturalLanguageSearchView: View {
                 HStack(spacing: 5) {
                     Image(systemName: "apple.intelligence")
                         .font(.caption)
-                        .foregroundStyle(Color.accentColor)
+                        .symbolRenderingMode(.multicolor)
                         .symbolEffect(.pulse, isActive: viewModel.isSearching)
                     Text("Apple Intelligence")
                         .font(.caption.bold())


### PR DESCRIPTION
 ## Summary                                                                                                                                                                          
  - NL 검색 탭에 AI thinking 메시지 박스 UI 추가 (검색 중 단계별 메시지 표시)
  - 기호(·✢✳︎✶✦✧) 순환 애니메이션으로 동적인 AI 활동 표현                                                                                                                              
  - Apple Intelligence 아이콘(multicolor) + 라벨 적용                                                                                                                                 
  - accentColor 기반 색상 테마 적용, 한국어/영어 로컬라이제이션 지원                                                                                                                  
  - 검색 X 버튼 클릭 시 화면 밀림 현상 수정                                                                                                                                           
                                                                     
  ## Changes                                                                                                                                                                          
  - `NaturalLanguageSearchView.swift` — `ThinkingPhase` enum, ViewModel 상태 관리(`resetState` 포함), `ThinkingMessageBox` 뷰, `ThinkingIndicatorView` 추가
  - `ContentView.swift` — searchText 비워질 때 상태 초기화 `onChange` 핸들러 추가                                                                                                     
  - `String+Extension.swift` — 새 로컬라이즈 문자열 프로퍼티 5개 추가                                                                                                                 
  - `en.lproj/Localizable.strings` — 영어 thinking 메시지 문자열 추가                                                                                                                 
  - `ko.lproj/Localizable.strings` — 한국어 thinking 메시지 문자열 추가                                                                                                               
                                                                     
  ## Test plan                                                                                                                                                                        
  - [ ] iOS 26.0 시뮬레이터에서 검색 탭 진입 후 쿼리 입력            
  - [ ] 메시지 박스가 단계별로 전환되는지 확인 (분석 → 검색 → 최적의 결과 찾기)                                                                                                       
  - [ ] Apple Intelligence 아이콘이 multicolor 그라데이션으로 표시되는지 확인                                                                                                         
  - [ ] 검색 완료 후 결과 개수 요약 표시 확인                                                                                                                                         
  - [ ] 결과 없을 때 적절한 메시지 표시 확인                                                                                                                                          
  - [ ] 검색 X 버튼 클릭 시 화면 밀림 없이 초기 상태로 돌아가는지 확인
  - [ ] 한국어/영어 로케일 전환 테스트                                                                                                                                                
  - [ ] 기존 modelStatusBanner(에러 상태)와 공존 확인                                                                                                                                 
                                                                                                                                                                                      
  Closes #14   