### PR TITLE
[hotfix][#17] iOS 26 미만 기기 크래시 수정 및 UI 개선

### DIFF
--- a/SF-Symbol-Finder/Resources/en.lproj/Localizable.strings
+++ b/SF-Symbol-Finder/Resources/en.lproj/Localizable.strings
@@ -43,14 +43,16 @@
 "NLThinkingFinding" = "Finding the best matches...";
 "NLThinkingDone" = "Found %d symbols";
 "NLThinkingNoResults" = "Couldn't find matching symbols";
+"NLSearchUnavailable" = "This feature requires iOS 26 or later.";
 
 /* Settings */
 "Settings" = "Settings";
 "SettingsLanguage" = "Language";
 "SettingsSFSymbols" = "SF Symbols";
-"SettingsSFSymbolsVersion" = "SF Symbols Version";
-"SettingsSFSymbolsVersionValue" = "5.1";
-"SettingsSFSymbolsCount" = "Symbol Count";
+"SettingsSFSymbolsSupportedVersions" = "Supported Versions";
+"SettingsSFSymbolsVersionDraw" = "Draw";
+"SettingsSFSymbolsVersionBrowse" = "All";
+"SettingsSFSymbolsVersionSearch" = "AI Search";
 "SettingsAppInfo" = "App Info";
 "SettingsCurrentVersion" = "Current Version";
 "SettingsChangeLanguage" = "Change Language";

--- a/SF-Symbol-Finder/Resources/ko.lproj/Localizable.strings
+++ b/SF-Symbol-Finder/Resources/ko.lproj/Localizable.strings
@@ -43,14 +43,16 @@
 "NLThinkingFinding" = "최적의 결과를 찾는 중...";
 "NLThinkingDone" = "%d개의 심볼을 찾았어요";
 "NLThinkingNoResults" = "일치하는 심볼을 찾지 못했어요";
+"NLSearchUnavailable" = "이 기능은 iOS 26 이상에서만 사용할 수 있어요.";
 
 /* Settings */
 "Settings" = "설정";
 "SettingsLanguage" = "언어";
 "SettingsSFSymbols" = "SF Symbols";
-"SettingsSFSymbolsVersion" = "SF Symbols 버전";
-"SettingsSFSymbolsVersionValue" = "5.1";
-"SettingsSFSymbolsCount" = "심볼 수";
+"SettingsSFSymbolsSupportedVersions" = "기능별 지원 버전";
+"SettingsSFSymbolsVersionDraw" = "그리기";
+"SettingsSFSymbolsVersionBrowse" = "전체";
+"SettingsSFSymbolsVersionSearch" = "AI 검색";
 "SettingsAppInfo" = "앱 정보";
 "SettingsCurrentVersion" = "현재 버전";
 "SettingsChangeLanguage" = "언어 변경";

--- a/SF-Symbol-Finder/Sources/Extensions/String+Extension.swift
+++ b/SF-Symbol-Finder/Sources/Extensions/String+Extension.swift
@@ -57,14 +57,16 @@ extension String {
     static let nlThinkingFinding = "NLThinkingFinding".localized()
     static let nlThinkingDone = "NLThinkingDone"
     static let nlThinkingNoResults = "NLThinkingNoResults".localized()
+    static let nlSearchUnavailable = "NLSearchUnavailable".localized()
 
     /* Settings */
     static let settings = "Settings".localized()
     static let settingsLanguage = "SettingsLanguage".localized()
     static let settingsSFSymbols = "SettingsSFSymbols".localized()
-    static let settingsSFSymbolsVersion = "SettingsSFSymbolsVersion".localized()
-    static let settingsSFSymbolsVersionValue = "SettingsSFSymbolsVersionValue".localized()
-    static let settingsSFSymbolsCount = "SettingsSFSymbolsCount".localized()
+    static let settingsSFSymbolsSupportedVersions = "SettingsSFSymbolsSupportedVersions".localized()
+    static let settingsSFSymbolsVersionDraw = "SettingsSFSymbolsVersionDraw".localized()
+    static let settingsSFSymbolsVersionBrowse = "SettingsSFSymbolsVersionBrowse".localized()
+    static let settingsSFSymbolsVersionSearch = "SettingsSFSymbolsVersionSearch".localized()
     static let settingsAppInfo = "SettingsAppInfo".localized()
     static let settingsCurrentVersion = "SettingsCurrentVersion".localized()
     static let settingsChangeLanguage = "SettingsChangeLanguage".localized()

--- a/SF-Symbol-Finder/Sources/Presentations/Main/ContentView.swift
+++ b/SF-Symbol-Finder/Sources/Presentations/Main/ContentView.swift
@@ -21,16 +21,6 @@ struct ContentView: View {
   @State private var searchMode: SearchMode = .draw
   @State private var isSearchActive = false
   @FocusState private var isSearchFieldFocused: Bool
-  @FocusState private var isSearchFocused: Bool
-#if canImport(FoundationModels)
-  @StateObject private var nlSearchViewModel = {
-    if #available(iOS 26.0, *) {
-      return NaturalLanguageSearchViewModel()
-    } else {
-      fatalError()
-    }
-  }()
-#endif
   @EnvironmentObject var orientation: Orientation
   var defaultPadding: CGFloat {
     Constants.deviceModel == DeviceModel.iPad.rawValue ? 30 : 10
@@ -46,6 +36,8 @@ struct ContentView: View {
             onAppeared = true
           }
         }
+    } else if #available(iOS 18.0, *) {
+      legacyTabViewBody
     } else {
       legacyBody
     }
@@ -57,6 +49,16 @@ struct ContentView: View {
 #if canImport(FoundationModels)
   @available(iOS 26.0, *)
   private var tabViewBody: some View {
+    DescribeTabWrapper(
+      searchMode: $searchMode,
+      showErrorAlert: showErrorAlert,
+      drawContent: { drawContent },
+      errorOverlay: { errorOverlay }
+    )
+  }
+
+  @available(iOS 18.0, *)
+  private var legacyTabViewBody: some View {
     ZStack {
       TabView(selection: $searchMode) {
         Tab(String.searchModeDraw, systemImage: "pencil.and.scribble", value: .draw) {
@@ -71,31 +73,32 @@ struct ContentView: View {
         Tab(String.settings, systemImage: "gearshape", value: .settings) {
           SettingsView()
         }
-        Tab(value: .describe, role: .search) {
-          NavigationStack {
-            ZStack {
-              Color.neutral.ignoresSafeArea()
-              NaturalLanguageSearchView(viewModel: nlSearchViewModel)
+        Tab(String.searchModeDescribe, systemImage: "magnifyingglass", value: .describe) {
+          ZStack {
+            Color.neutral.ignoresSafeArea()
+            VStack(spacing: 16) {
+              Image(systemName: "apple.intelligence")
+                .font(.system(size: 40))
+                .foregroundStyle(.secondary)
+              Text(String.nlSearchUnavailable)
+                .font(.body)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
             }
-          }
-          .searchable(text: $nlSearchViewModel.searchText, placement: .automatic, prompt: String.nlSearchPlaceholder)
-          .searchFocused($isSearchFocused)
-          .onSubmit(of: .search) { nlSearchViewModel.performSearch() }
-          .onChange(of: nlSearchViewModel.searchText) {
-            if nlSearchViewModel.searchText.isEmpty {
-              nlSearchViewModel.resetState()
-            }
-          }
-          .onChange(of: searchMode) {
-            if searchMode == .describe {
-              isSearchFocused = true
-            }
+            .padding()
           }
         }
       }
+      .onAppear { configureTabBarAppearance() }
 
       if showErrorAlert {
         errorOverlay
+      }
+    }
+    .onAppear {
+      if !onAppeared {
+        canvasRepresentingView = CanvasRepresentingView(isClear: $isClear)
+        onAppeared = true
       }
     }
   }
@@ -192,3 +195,94 @@ struct ContentView: View {
     .padding(.horizontal, defaultPadding)
   }
 }
+
+// MARK: - Tab Bar Appearance
+private func configureTabBarAppearance() {
+  let appearance = UITabBarAppearance()
+  appearance.configureWithOpaqueBackground()
+  appearance.backgroundColor = UIColor(Color.neutral)
+
+  let normalAttributes: [NSAttributedString.Key: Any] = [
+    .foregroundColor: UIColor.white.withAlphaComponent(0.6)
+  ]
+  let selectedAttributes: [NSAttributedString.Key: Any] = [
+    .foregroundColor: UIColor(Color.accentColor)
+  ]
+
+  appearance.stackedLayoutAppearance.normal.iconColor = UIColor.white.withAlphaComponent(0.6)
+  appearance.stackedLayoutAppearance.normal.titleTextAttributes = normalAttributes
+  appearance.stackedLayoutAppearance.selected.iconColor = UIColor(Color.accentColor)
+  appearance.stackedLayoutAppearance.selected.titleTextAttributes = selectedAttributes
+
+  appearance.inlineLayoutAppearance.normal.iconColor = UIColor.white.withAlphaComponent(0.6)
+  appearance.inlineLayoutAppearance.normal.titleTextAttributes = normalAttributes
+  appearance.inlineLayoutAppearance.selected.iconColor = UIColor(Color.accentColor)
+  appearance.inlineLayoutAppearance.selected.titleTextAttributes = selectedAttributes
+
+  appearance.compactInlineLayoutAppearance.normal.iconColor = UIColor.white.withAlphaComponent(0.6)
+  appearance.compactInlineLayoutAppearance.normal.titleTextAttributes = normalAttributes
+  appearance.compactInlineLayoutAppearance.selected.iconColor = UIColor(Color.accentColor)
+  appearance.compactInlineLayoutAppearance.selected.titleTextAttributes = selectedAttributes
+
+  UITabBar.appearance().standardAppearance = appearance
+  UITabBar.appearance().scrollEdgeAppearance = appearance
+}
+
+// MARK: - iOS 26+ Tab Wrapper
+#if canImport(FoundationModels)
+@available(iOS 26.0, *)
+private struct DescribeTabWrapper<DrawContent: View, ErrorOverlay: View>: View {
+  @Binding var searchMode: SearchMode
+  let showErrorAlert: Bool
+  @ViewBuilder let drawContent: () -> DrawContent
+  @ViewBuilder let errorOverlay: () -> ErrorOverlay
+
+  @StateObject private var nlSearchViewModel = NaturalLanguageSearchViewModel()
+  @FocusState private var isSearchFocused: Bool
+
+  var body: some View {
+    ZStack {
+      TabView(selection: $searchMode) {
+        Tab(String.searchModeDraw, systemImage: "pencil.and.scribble", value: .draw) {
+          drawContent()
+        }
+        Tab(String.searchModeBrowse, systemImage: "square.grid.2x2", value: .browse) {
+          ZStack {
+            Color.neutral.ignoresSafeArea()
+            SFSymbolListView(keyword: "")
+          }
+        }
+        Tab(String.settings, systemImage: "gearshape", value: .settings) {
+          SettingsView()
+        }
+        Tab(value: .describe, role: .search) {
+          NavigationStack {
+            ZStack {
+              Color.neutral.ignoresSafeArea()
+              NaturalLanguageSearchView(viewModel: nlSearchViewModel)
+            }
+          }
+          .searchable(text: $nlSearchViewModel.searchText, placement: .automatic, prompt: String.nlSearchPlaceholder)
+          .searchFocused($isSearchFocused)
+          .onSubmit(of: .search) { nlSearchViewModel.performSearch() }
+          .onChange(of: nlSearchViewModel.searchText) {
+            if nlSearchViewModel.searchText.isEmpty {
+              nlSearchViewModel.resetState()
+            }
+          }
+          .onChange(of: searchMode) {
+            if searchMode == .describe {
+              isSearchFocused = true
+            }
+          }
+        }
+      }
+
+      if showErrorAlert {
+        errorOverlay()
+      }
+    }
+    .onAppear { configureTabBarAppearance() }
+  }
+}
+#endif

--- a/SF-Symbol-Finder/Sources/Presentations/Main/SFSymbolListView.swift
+++ b/SF-Symbol-Finder/Sources/Presentations/Main/SFSymbolListView.swift
@@ -23,7 +23,7 @@ struct SFSymbolListView: View {
     @Environment(\.dismiss) private var dismiss
     var body: some View {
         ZStack {
-            Color.neutral
+            Color.neutral.ignoresSafeArea()
             ScrollView {
                 VStack {
                     Text(String.guideOnClickToCopy)

--- a/SF-Symbol-Finder/Sources/Presentations/NaturalLanguageSearch/NaturalLanguageSearchView.swift
+++ b/SF-Symbol-Finder/Sources/Presentations/NaturalLanguageSearch/NaturalLanguageSearchView.swift
@@ -155,7 +155,7 @@ struct NaturalLanguageSearchView: View {
                         .font(.caption)
                         .symbolRenderingMode(.multicolor)
                         .symbolEffect(.pulse, isActive: viewModel.isSearching)
-                    Text("Apple Intelligence")
+                    Text("Apple Foundation Model")
                         .font(.caption.bold())
                         .foregroundStyle(Color.accentColor)
                 }

--- a/SF-Symbol-Finder/Sources/Presentations/Settings/SettingsView.swift
+++ b/SF-Symbol-Finder/Sources/Presentations/Settings/SettingsView.swift
@@ -18,12 +18,24 @@ struct SettingsView: View {
         appInfoSection
       }
       .scrollContentBackground(.hidden)
+      .listStyle(.insetGrouped)
+      .environment(\.defaultMinListRowHeight, 44)
     }
+  }
+
+  private var cellBackground: Color {
+    Color.white.opacity(0.08)
+  }
+
+  private func sectionHeader(_ title: String) -> some View {
+    Text(title)
+      .foregroundStyle(Color.white.opacity(0.7))
+      .font(.footnote)
   }
 
   // MARK: - Language
   private var languageSection: some View {
-    Section(header: Text(String.settingsLanguage)) {
+    Section(header: sectionHeader(String.settingsLanguage)) {
       Button {
         if let url = URL(string: UIApplication.openSettingsURLString) {
           UIApplication.shared.open(url)
@@ -31,45 +43,53 @@ struct SettingsView: View {
       } label: {
         HStack {
           Text(String.settingsChangeLanguage)
-            .foregroundStyle(.primary)
+            .foregroundStyle(.white)
           Spacer()
           Text(AppLanguage.current.displayName)
-            .foregroundStyle(.secondary)
+            .foregroundStyle(Color.white.opacity(0.5))
           Image(systemName: "chevron.right")
             .font(.caption)
-            .foregroundStyle(.secondary)
+            .foregroundStyle(Color.white.opacity(0.5))
         }
       }
+      .listRowBackground(cellBackground)
+      .listRowSeparatorTint(Color.white.opacity(0.15))
     }
   }
 
   // MARK: - SF Symbols
   private var sfSymbolsSection: some View {
-    Section(header: Text(String.settingsSFSymbols)) {
-      HStack {
-        Text(String.settingsSFSymbolsVersion)
-        Spacer()
-        Text(String.settingsSFSymbolsVersionValue)
-          .foregroundStyle(.secondary)
-      }
-      HStack {
-        Text(String.settingsSFSymbolsCount)
-        Spacer()
-        Text("\(Constants.sfsymbols.count)")
-          .foregroundStyle(.secondary)
-      }
+    Section(header: sectionHeader(String.settingsSFSymbolsSupportedVersions)) {
+      versionRow(feature: String.settingsSFSymbolsVersionDraw, version: "SF Symbols 5.1 / iOS 16+")
+      versionRow(feature: String.settingsSFSymbolsVersionBrowse, version: "SF Symbols 7.2 / iOS 16+")
+      versionRow(feature: String.settingsSFSymbolsVersionSearch, version: "SF Symbols 7.2 / iOS 26+")
     }
+  }
+
+  private func versionRow(feature: String, version: String) -> some View {
+    HStack {
+      Text(feature)
+        .foregroundStyle(.white)
+      Spacer()
+      Text(version)
+        .foregroundStyle(Color.white.opacity(0.5))
+    }
+    .listRowBackground(cellBackground)
+    .listRowSeparatorTint(Color.white.opacity(0.15))
   }
 
   // MARK: - App Info
   private var appInfoSection: some View {
-    Section(header: Text(String.settingsAppInfo)) {
+    Section(header: sectionHeader(String.settingsAppInfo)) {
       HStack {
         Text(String.settingsCurrentVersion)
+          .foregroundStyle(.white)
         Spacer()
         Text(Bundle.main.appVersion)
-          .foregroundStyle(.secondary)
+          .foregroundStyle(Color.white.opacity(0.5))
       }
+      .listRowBackground(cellBackground)
+      .listRowSeparatorTint(Color.white.opacity(0.15))
     }
   }
 }


### PR DESCRIPTION
  ## Summary                                                                                                                                                                       
  - Xcode 26 빌드 시 `#if canImport(FoundationModels)` 블록이 컴파일에 포함되지만, iOS 26 미만 기기에서 `nlSearchViewModel` 초기화 클로저의 `fatalError()`가 호출되어 즉시 크래시  
  발생하는 문제 수정                                                                                                                                                               
  - iOS 26 미만 기기에서의 UI 대응 및 다크 테마 스타일링 개선                                                                                                                      
                                                                                                                                                                                   
  ## Changes                                                                                                                                                                       
                                                                                                                                                                                   
  ### 크래시 수정 — `ContentView.swift`                                                                                                                                            
  - `fatalError()` 호출하던 `@StateObject` 제거                                                                                                                                    
  - `DescribeTabWrapper`로 iOS 26+ 전용 `@StateObject` 안전하게 분리                                                                                                               
  - body 분기를 3단계로 정리:                                                                                                                                                      
    - `iOS 26+` → `tabViewBody` (AI 검색 포함 4탭)                                                                                                                                 
    - `iOS 18+` → `legacyTabViewBody` (4탭, Describe 탭에 안내 메시지)                                                                                                             
    - `iOS <18` → `legacyBody` (Draw만)                                                                                                                                            
                                                                                                                                                                                   
  ### UI 개선                                                                                                                                                                      
  - **탭바 색상**: accentColor(선택) / white 60%(비선택) / neutral 배경                                                                                                            
  - **SFSymbolListView**: `Color.neutral`에 `.ignoresSafeArea()` 누락 수정 (Browse 탭 흰색 배경 문제)                                                                              
  - **설정 화면 다크 테마**: 셀 배경(`white 8%`), 텍스트(white), 섹션 타이틀(`white 70%`), 구분선(`white 15%`)                                                                     
  - **설정 화면 기능별 최소 버전 표기**:                                                                                                                                           
    - Draw: `SF Symbols 5.1 / iOS 16+`                                                                                                                                             
    - Browse: `SF Symbols 7.2 / iOS 16+`                                                                                                                                           
    - AI Search: `SF Symbols 7.2 / iOS 26+`                                                                                                                                        
                                                                                                                                                                                   
  ### 기타                                                                                                                                                                         
  - Thinking 박스 라벨: `Apple Intelligence` → `Apple Foundation Model`                                                                                                            
  - 새 로컬라이징 문자열 `NLSearchUnavailable` 추가 (ko/en)                                                                                                                        
                                                                                                                                                                                   
  ## Test Plan                                                                                                                                                                     
  - [ ] iOS 26 미만 시뮬레이터에서 크래시 없이 실행                                                                                                                                
  - [ ] iOS 26 미만: Describe 탭 → 안내 메시지 표시                                                                                                                                
  - [ ] iOS 26+: 기존과 동일 동작                                                                                                                                                  
  - [ ] Browse 탭 배경색 정상 (흰색 X)                                                                                                                                             
  - [ ] 탭바 선택/비선택 색상 확인                                                                                                                                                 
  - [ ] 설정 화면 다크 테마 스타일링 확인   