### PR TITLE
[feat][#18] 전체보기 탭에 검색 및 카테고리 필터 추가

### DIFF
--- a/SF-Symbol-Finder.xcodeproj/project.pbxproj
+++ b/SF-Symbol-Finder.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		CC0000032C8A000100000001 /* FoundationModelService.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0000042C8A000100000001 /* FoundationModelService.swift */; };
 		CC0000052C8A000100000001 /* NaturalLanguageSearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0000062C8A000100000001 /* NaturalLanguageSearchView.swift */; };
 		CC0000092C8A000100000001 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC00000A2C8A000100000001 /* SettingsView.swift */; };
+		CC00000C2C8A000200000001 /* SymbolCategory.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC00000D2C8A000200000001 /* SymbolCategory.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -57,6 +58,7 @@
 		CC0000042C8A000100000001 /* FoundationModelService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoundationModelService.swift; sourceTree = "<group>"; };
 		CC0000062C8A000100000001 /* NaturalLanguageSearchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NaturalLanguageSearchView.swift; sourceTree = "<group>"; };
 		CC00000A2C8A000100000001 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
+		CC00000D2C8A000200000001 /* SymbolCategory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SymbolCategory.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -182,6 +184,7 @@
 				ADD4C0302B95C28500B6E862 /* Result.swift */,
 				AD548E0C2B960C6200FBB2CC /* DeviceModel.swift */,
 				CC0000022C8A000100000001 /* SymbolKeywords.swift */,
+				CC00000D2C8A000200000001 /* SymbolCategory.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -311,6 +314,7 @@
 				CC0000032C8A000100000001 /* FoundationModelService.swift in Sources */,
 				CC0000052C8A000100000001 /* NaturalLanguageSearchView.swift in Sources */,
 				CC0000092C8A000100000001 /* SettingsView.swift in Sources */,
+				CC00000C2C8A000200000001 /* SymbolCategory.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/SF-Symbol-Finder/Resources/en.lproj/Localizable.strings
+++ b/SF-Symbol-Finder/Resources/en.lproj/Localizable.strings
@@ -44,6 +44,27 @@
 "NLThinkingDone" = "Found %d symbols";
 "NLThinkingNoResults" = "Couldn't find matching symbols";
 
+/* Browse Search */
+"BrowseSearchPlaceholder" = "Search symbols...";
+"BrowseNoResults" = "No symbols found.\nTry a different search term or category.";
+
+/* Categories */
+"CategoryAll" = "All";
+"CategoryCommunication" = "Communication";
+"CategoryWeather" = "Weather";
+"CategoryHuman" = "People";
+"CategoryNature" = "Nature";
+"CategoryDevices" = "Devices";
+"CategoryTransportation" = "Transport";
+"CategoryGaming" = "Gaming";
+"CategoryArrows" = "Arrows";
+"CategoryMedia" = "Media";
+"CategoryEditing" = "Editing";
+"CategoryCommerce" = "Commerce";
+"CategoryHealth" = "Health";
+"CategoryObjects" = "Objects";
+"CategoryShapes" = "Shapes";
+
 /* Settings */
 "Settings" = "Settings";
 "SettingsLanguage" = "Language";

--- a/SF-Symbol-Finder/Resources/ko.lproj/Localizable.strings
+++ b/SF-Symbol-Finder/Resources/ko.lproj/Localizable.strings
@@ -44,6 +44,27 @@
 "NLThinkingDone" = "%d개의 심볼을 찾았어요";
 "NLThinkingNoResults" = "일치하는 심볼을 찾지 못했어요";
 
+/* Browse Search */
+"BrowseSearchPlaceholder" = "심볼 검색...";
+"BrowseNoResults" = "심볼을 찾지 못했어요.\n다른 검색어나 카테고리를 시도해 보세요.";
+
+/* Categories */
+"CategoryAll" = "전체";
+"CategoryCommunication" = "커뮤니케이션";
+"CategoryWeather" = "날씨";
+"CategoryHuman" = "사람";
+"CategoryNature" = "자연";
+"CategoryDevices" = "기기";
+"CategoryTransportation" = "교통";
+"CategoryGaming" = "게임";
+"CategoryArrows" = "화살표";
+"CategoryMedia" = "미디어";
+"CategoryEditing" = "편집";
+"CategoryCommerce" = "상거래";
+"CategoryHealth" = "건강";
+"CategoryObjects" = "오브젝트";
+"CategoryShapes" = "도형";
+
 /* Settings */
 "Settings" = "설정";
 "SettingsLanguage" = "언어";

--- a/SF-Symbol-Finder/Sources/Extensions/String+Extension.swift
+++ b/SF-Symbol-Finder/Sources/Extensions/String+Extension.swift
@@ -58,6 +58,27 @@ extension String {
     static let nlThinkingDone = "NLThinkingDone"
     static let nlThinkingNoResults = "NLThinkingNoResults".localized()
 
+    /* Browse Search */
+    static let browseSearchPlaceholder = "BrowseSearchPlaceholder".localized()
+    static let browseNoResults = "BrowseNoResults".localized()
+
+    /* Categories */
+    static let categoryAll = "CategoryAll".localized()
+    static let categoryCommunication = "CategoryCommunication".localized()
+    static let categoryWeather = "CategoryWeather".localized()
+    static let categoryHuman = "CategoryHuman".localized()
+    static let categoryNature = "CategoryNature".localized()
+    static let categoryDevices = "CategoryDevices".localized()
+    static let categoryTransportation = "CategoryTransportation".localized()
+    static let categoryGaming = "CategoryGaming".localized()
+    static let categoryArrows = "CategoryArrows".localized()
+    static let categoryMedia = "CategoryMedia".localized()
+    static let categoryEditing = "CategoryEditing".localized()
+    static let categoryCommerce = "CategoryCommerce".localized()
+    static let categoryHealth = "CategoryHealth".localized()
+    static let categoryObjects = "CategoryObjects".localized()
+    static let categoryShapes = "CategoryShapes".localized()
+
     /* Settings */
     static let settings = "Settings".localized()
     static let settingsLanguage = "SettingsLanguage".localized()

--- a/SF-Symbol-Finder/Sources/Models/SymbolCategory.swift
+++ b/SF-Symbol-Finder/Sources/Models/SymbolCategory.swift
@@ -1,0 +1,171 @@
+//
+//  SymbolCategory.swift
+//  SF-Symbol-Finder
+//
+//  Created by 제나 on 3/20/26.
+//
+
+import Foundation
+
+enum SymbolCategory: String, CaseIterable {
+    case all
+    case communication
+    case weather
+    case human
+    case nature
+    case devices
+    case transportation
+    case gaming
+    case arrows
+    case media
+    case editing
+    case commerce
+    case health
+    case objects
+    case shapes
+
+    var displayName: String {
+        switch self {
+        case .all: return String.categoryAll
+        case .communication: return String.categoryCommunication
+        case .weather: return String.categoryWeather
+        case .human: return String.categoryHuman
+        case .nature: return String.categoryNature
+        case .devices: return String.categoryDevices
+        case .transportation: return String.categoryTransportation
+        case .gaming: return String.categoryGaming
+        case .arrows: return String.categoryArrows
+        case .media: return String.categoryMedia
+        case .editing: return String.categoryEditing
+        case .commerce: return String.categoryCommerce
+        case .health: return String.categoryHealth
+        case .objects: return String.categoryObjects
+        case .shapes: return String.categoryShapes
+        }
+    }
+
+    var iconName: String {
+        switch self {
+        case .all: return "square.grid.2x2"
+        case .communication: return "message"
+        case .weather: return "cloud.sun"
+        case .human: return "person"
+        case .nature: return "leaf"
+        case .devices: return "desktopcomputer"
+        case .transportation: return "car"
+        case .gaming: return "gamecontroller"
+        case .arrows: return "arrow.right"
+        case .media: return "play"
+        case .editing: return "pencil"
+        case .commerce: return "cart"
+        case .health: return "heart"
+        case .objects: return "archivebox"
+        case .shapes: return "circle"
+        }
+    }
+
+    private var keywords: [String] {
+        switch self {
+        case .all: return []
+        case .communication: return [
+            "message", "phone", "envelope", "mail", "bubble", "call",
+            "video", "mic", "speaker", "antenna", "wifi", "teletype",
+            "megaphone", "bell", "chat"
+        ]
+        case .weather: return [
+            "cloud", "sun", "moon", "rain", "snow", "wind", "bolt",
+            "thermometer", "humidity", "tornado", "tropicalstorm",
+            "hurricane", "snowflake", "fog", "haze", "sunrise", "sunset"
+        ]
+        case .human: return [
+            "person", "figure", "hand", "face", "eye", "ear", "nose",
+            "mouth", "brain", "accessibility", "body", "head", "foot",
+            "arm", "leg", "thumb"
+        ]
+        case .nature: return [
+            "leaf", "tree", "flower", "ant", "ladybug", "fish", "bird",
+            "tortoise", "hare", "cat", "dog", "pawprint", "flame",
+            "drop", "mountain", "globe", "water", "fossil", "carrot"
+        ]
+        case .devices: return [
+            "desktopcomputer", "laptop", "keyboard", "display", "tv",
+            "iphone", "ipad", "applewatch", "airpod", "homepod",
+            "printer", "server", "cpu", "memorychip", "battery",
+            "power", "plug", "cable", "sensor", "chip", "monitor",
+            "headphones", "airplay", "computermouse", "magicmouse",
+            "macbook", "macmini", "macpro", "appletv", "visionpro"
+        ]
+        case .transportation: return [
+            "car", "bus", "tram", "bicycle", "scooter", "airplane",
+            "ferry", "train", "road", "fuelpump", "steeringwheel",
+            "engine", "gauge", "parkingsign", "ev"
+        ]
+        case .gaming: return [
+            "gamecontroller", "dpad", "joystick", "playstation",
+            "xbox", "logo.playstation", "logo.xbox", "trophy",
+            "medal", "flag.checkered", "puzzle", "dice"
+        ]
+        case .arrows: return [
+            "arrow", "chevron", "arrowshape", "triangle",
+            "return", "restart", "repeat", "shuffle"
+        ]
+        case .media: return [
+            "play", "pause", "stop", "record", "forward", "backward",
+            "speaker", "music", "note", "headphones", "radio",
+            "film", "camera", "photo", "video", "waveform",
+            "airplay", "pip", "rectangle.on.rectangle", "antenna",
+            "tv", "hifispeaker", "appletv"
+        ]
+        case .editing: return [
+            "pencil", "eraser", "paintbrush", "paintpalette", "eyedropper",
+            "crop", "ruler", "scissors", "scribble", "highlighter",
+            "lasso", "wand", "slider", "dial", "tuningfork",
+            "line.diagonal", "selection.pin"
+        ]
+        case .commerce: return [
+            "cart", "bag", "creditcard", "giftcard", "banknote",
+            "wallet", "barcode", "qrcode", "storefront", "basket",
+            "tag", "purchased", "dollarsign", "eurosign", "yensign",
+            "sterlingsign", "indianrupeesign"
+        ]
+        case .health: return [
+            "heart", "cross", "staroflife", "pills", "syringe",
+            "bandage", "stethoscope", "medical", "waveform.path",
+            "lungs", "allergens", "bolt.heart", "pulse",
+            "ivfluid", "microbe"
+        ]
+        case .objects: return [
+            "folder", "doc", "book", "bookmark", "calendar",
+            "clock", "alarm", "timer", "stopwatch", "hourglass",
+            "lock", "key", "pin", "map", "magnifyingglass",
+            "link", "paperclip", "trash", "tray", "archivebox",
+            "bin", "cup", "mug", "wineglass", "fork", "lightbulb",
+            "lamp", "flashlight", "binoculars", "wrench", "hammer",
+            "screwdriver", "briefcase", "suitcase", "backpack",
+            "umbrella", "gift", "party"
+        ]
+        case .shapes: return [
+            "circle", "square", "rectangle", "triangle", "diamond",
+            "hexagon", "pentagon", "octagon", "oval", "capsule",
+            "seal", "star", "shield", "rhombus", "app"
+        ]
+        }
+    }
+
+    static func buildIndex(symbols: [String]) -> [SymbolCategory: Set<String>] {
+        var index = [SymbolCategory: Set<String>]()
+        for category in SymbolCategory.allCases where category != .all {
+            var matched = Set<String>()
+            for symbol in symbols {
+                for keyword in category.keywords {
+                    if symbol.contains(keyword) {
+                        matched.insert(symbol)
+                        break
+                    }
+                }
+            }
+            index[category] = matched
+        }
+        return index
+    }
+}

--- a/SF-Symbol-Finder/Sources/Presentations/Main/ContentView.swift
+++ b/SF-Symbol-Finder/Sources/Presentations/Main/ContentView.swift
@@ -22,6 +22,7 @@ struct ContentView: View {
   @State private var isSearchActive = false
   @FocusState private var isSearchFieldFocused: Bool
   @FocusState private var isSearchFocused: Bool
+  @State private var browseSearchText = ""
 #if canImport(FoundationModels)
   @StateObject private var nlSearchViewModel = {
     if #available(iOS 26.0, *) {
@@ -65,7 +66,7 @@ struct ContentView: View {
         Tab(String.searchModeBrowse, systemImage: "square.grid.2x2", value: .browse) {
           ZStack {
             Color.neutral.ignoresSafeArea()
-            SFSymbolListView(keyword: "")
+            SFSymbolListView(keyword: "", searchText: $browseSearchText)
           }
         }
         Tab(String.settings, systemImage: "gearshape", value: .settings) {

--- a/SF-Symbol-Finder/Sources/Presentations/Main/SFSymbolListView.swift
+++ b/SF-Symbol-Finder/Sources/Presentations/Main/SFSymbolListView.swift
@@ -9,112 +9,247 @@ import SwiftUI
 
 struct SFSymbolListView: View {
     let keyword: String
+    @Binding var searchText: String
+    @State private var selectedCategory: SymbolCategory = .all
+
+    private var isBrowseMode: Bool { keyword.isEmpty }
+
     private var keywordReplaced: String {
         keyword.replacingOccurrences(of: "_", with: ".")
     }
-    private var systemNames: [String] {
-        if keywordReplaced.isEmpty {
-            return Constants.sfsymbols
+
+    private static let categoryIndex: [SymbolCategory: Set<String>] = {
+        SymbolCategory.buildIndex(symbols: Constants.sfsymbols)
+    }()
+
+    private var filteredSymbols: [String] {
+        var symbols = Constants.sfsymbols
+
+        if isBrowseMode {
+            if selectedCategory != .all,
+               let categorySymbols = Self.categoryIndex[selectedCategory] {
+                symbols = symbols.filter { categorySymbols.contains($0) }
+            }
+            if !searchText.isEmpty {
+                let query = searchText.lowercased()
+                symbols = symbols.filter { $0.contains(query) }
+            }
+        } else {
+            symbols = symbols.filter { $0.contains(keywordReplaced) }
         }
-        return Constants.sfsymbols.filter({ $0.contains(keywordReplaced)})
+
+        return symbols
     }
+
+    init(keyword: String, searchText: Binding<String> = .constant("")) {
+        self.keyword = keyword
+        self._searchText = searchText
+    }
+
     @State private var showClipboardAlert = false
     @State private var selectedSymbol: String?
     @Environment(\.dismiss) private var dismiss
+
     var body: some View {
         ZStack {
             Color.neutral
-            ScrollView {
-                VStack {
-                    Text(String.guideOnClickToCopy)
-                        .font(.headline)
-                        .foregroundStyle(Color.accentColor)
-                    LazyVGrid(columns: [GridItem()]) {
-                        ForEach(systemNames, id: \.self) { systemName in
-                            ZStack {
-                                Rectangle()
-                                    .stroke(Color.accentColor, lineWidth: 0.5)
-                                    .background(selectedSymbol == systemName ? Color.accentColor.opacity(0.3) : Color.neutral)
-                                HStack(spacing: 10) {
-                                    Image(systemName: systemName)
-                                        .font(.largeTitle)
-                                        .padding()
-                                        .foregroundStyle(.white)
-                                        .frame(width: 80)
-                                    Text(systemName)
-                                        .font(.subheadline)
-                                        .foregroundStyle(.white)
-                                    Spacer()
-                                }
-                            }
-                            .onTapGesture {
-                                UIPasteboard.general.string = systemName
-                                selectedSymbol = systemName
-                                showClipboardAlert = true
-                                DispatchQueue.main.asyncAfter(deadline: .now() + 0.7) {
-                                    selectedSymbol = nil
-                                }
-                            }
-                        }
-                    }
+            VStack(spacing: 0) {
+                if isBrowseMode {
+                    browseHeader
                 }
-                .padding()
-                .padding(.top, 40)
-            }
-            if !keyword.isEmpty {
-                VStack {
-                    ZStack {
-                        HStack {
-                            Spacer()
-                            Text(keywordReplaced)
+                ScrollView {
+                    VStack {
+                        if !isBrowseMode {
+                            Text(String.guideOnClickToCopy)
+                                .font(.headline)
                                 .foregroundStyle(Color.accentColor)
-                                .font(.body)
-                            Spacer()
                         }
-                        HStack {
-                            Button {
-                                dismiss()
-                            } label: {
-                                Image(systemName: .chevronBackward)
-                                    .font(.headline)
-                                    .fontWeight(.bold)
-                                    .foregroundStyle(Color.accentColor)
-                            }
-                            .padding()
-                            Spacer()
+                        if filteredSymbols.isEmpty {
+                            emptyStateView
+                        } else {
+                            symbolGrid
                         }
                     }
-                    .background(Color.black.opacity(0.3))
-                    Spacer()
-                    Spacer()
+                    .padding()
+                    .padding(.top, isBrowseMode ? 8 : 40)
                 }
             }
-            
+
+            if !keyword.isEmpty {
+                keywordHeader
+            }
+
             if showClipboardAlert {
-                Color
-                    .black
-                    .opacity(0.7)
-                    .ignoresSafeArea()
-                HStack(spacing: 10) {
-                    Image(systemName: .docOnClipboard)
-                        .font(.title3)
-                        .foregroundStyle(.white)
-                    Text(String.alertCopied)
-                        .font(.title3)
-                        .foregroundStyle(.white)
+                clipboardAlertOverlay
+            }
+        }
+        .navigationBarHidden(true)
+    }
+
+    // MARK: - Browse Header (Search Bar + Category Chips)
+
+    private var browseHeader: some View {
+        VStack(spacing: 12) {
+            HStack {
+                Image(systemName: "magnifyingglass")
+                    .foregroundStyle(.gray)
+                TextField(String.browseSearchPlaceholder, text: $searchText)
+                    .autocorrectionDisabled()
+                    .textInputAutocapitalization(.never)
+                if !searchText.isEmpty {
+                    Button {
+                        searchText = ""
+                    } label: {
+                        Image(systemName: "xmark.circle.fill")
+                            .foregroundStyle(.gray)
+                    }
                 }
-                .padding()
-                .background(
-                    RoundedRectangle(cornerRadius: 8)
-                        .foregroundColor(.gray.opacity(0.5))
-                )
-                .onAppear {
+            }
+            .padding(10)
+            .background(Color.white.opacity(0.1))
+            .cornerRadius(10)
+            .padding(.horizontal)
+
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 8) {
+                    ForEach(SymbolCategory.allCases, id: \.self) { category in
+                        categoryChip(category)
+                    }
+                }
+                .padding(.horizontal)
+            }
+        }
+        .padding(.top, 12)
+        .padding(.bottom, 4)
+        .background(Color.neutral)
+    }
+
+    private func categoryChip(_ category: SymbolCategory) -> some View {
+        let isSelected = selectedCategory == category
+        return Button {
+            withAnimation(.easeInOut(duration: 0.2)) {
+                selectedCategory = category
+            }
+        } label: {
+            HStack(spacing: 4) {
+                Image(systemName: category.iconName)
+                    .font(.caption2)
+                Text(category.displayName)
+                    .font(.caption)
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 6)
+            .background(isSelected ? Color.accentColor : Color.white.opacity(0.1))
+            .foregroundStyle(isSelected ? .black : .white)
+            .clipShape(Capsule())
+        }
+    }
+
+    // MARK: - Symbol Grid
+
+    private var symbolGrid: some View {
+        LazyVGrid(columns: [GridItem()]) {
+            ForEach(filteredSymbols, id: \.self) { systemName in
+                ZStack {
+                    Rectangle()
+                        .stroke(Color.accentColor, lineWidth: 0.5)
+                        .background(selectedSymbol == systemName ? Color.accentColor.opacity(0.3) : Color.neutral)
+                    HStack(spacing: 10) {
+                        Image(systemName: systemName)
+                            .font(.largeTitle)
+                            .padding()
+                            .foregroundStyle(.white)
+                            .frame(width: 80)
+                        Text(systemName)
+                            .font(.subheadline)
+                            .foregroundStyle(.white)
+                        Spacer()
+                    }
+                }
+                .onTapGesture {
+                    UIPasteboard.general.string = systemName
+                    selectedSymbol = systemName
+                    showClipboardAlert = true
                     DispatchQueue.main.asyncAfter(deadline: .now() + 0.7) {
-                        showClipboardAlert = false
+                        selectedSymbol = nil
                     }
                 }
             }
         }
-        .navigationBarHidden(true)
+    }
+
+    // MARK: - Empty State
+
+    private var emptyStateView: some View {
+        VStack(spacing: 16) {
+            Image(systemName: "magnifyingglass")
+                .font(.system(size: 48))
+                .foregroundStyle(.gray)
+            Text(String.browseNoResults)
+                .font(.body)
+                .foregroundStyle(.gray)
+                .multilineTextAlignment(.center)
+        }
+        .padding(.top, 80)
+    }
+
+    // MARK: - Keyword Header (Draw mode)
+
+    private var keywordHeader: some View {
+        VStack {
+            ZStack {
+                HStack {
+                    Spacer()
+                    Text(keywordReplaced)
+                        .foregroundStyle(Color.accentColor)
+                        .font(.body)
+                    Spacer()
+                }
+                HStack {
+                    Button {
+                        dismiss()
+                    } label: {
+                        Image(systemName: .chevronBackward)
+                            .font(.headline)
+                            .fontWeight(.bold)
+                            .foregroundStyle(Color.accentColor)
+                    }
+                    .padding()
+                    Spacer()
+                }
+            }
+            .background(Color.black.opacity(0.3))
+            Spacer()
+            Spacer()
+        }
+    }
+
+    // MARK: - Clipboard Alert
+
+    private var clipboardAlertOverlay: some View {
+        ZStack {
+            Color
+                .black
+                .opacity(0.7)
+                .ignoresSafeArea()
+            HStack(spacing: 10) {
+                Image(systemName: .docOnClipboard)
+                    .font(.title3)
+                    .foregroundStyle(.white)
+                Text(String.alertCopied)
+                    .font(.title3)
+                    .foregroundStyle(.white)
+            }
+            .padding()
+            .background(
+                RoundedRectangle(cornerRadius: 8)
+                    .foregroundColor(.gray.opacity(0.5))
+            )
+            .onAppear {
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.7) {
+                    showClipboardAlert = false
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                                                                       
  - 전체보기(Browse) 탭에 **인라인 검색바**와 **카테고리 필터 칩** 추가                                                                                                                                                                            
  - 15개 카테고리(전체, 커뮤니케이션, 날씨, 사람, 자연, 기기, 교통, 게임, 화살표, 미디어, 편집, 상거래, 건강, 오브젝트, 도형) 지원                                                                                                                 
  - 카테고리 선택 → 검색어 입력 순서로 체이닝 필터링 동작                                                                                                                                                                                          
  - 검색 결과 없을 때 빈 상태(empty state) UI 표시                                                                                                                                                                                                 
  - en/ko 로컬라이제이션 지원                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                   
  ## Changes                                                                                                                                                                                                                                       
  | 파일 | 변경 |                                                                                                                                                                                                                                  
  |------|------|                                                                                                                                                                                                                                  
  | `SymbolCategory.swift` | **NEW** — 카테고리 enum, 키워드 패턴, 사전 인덱스 빌더 |                                                                                                                                                              
  | `SFSymbolListView.swift` | Browse 모드 분기 추가 (검색바 + 카테고리 칩 + 필터링) |                                                                                                                                                             
  | `ContentView.swift` | `browseSearchText` 상태 추가 및 바인딩 전달 |                                                                                                                                                                            
  | `String+Extension.swift` | 검색/카테고리 로컬라이즈 문자열 추가 |                                                                                                                                                                              
  | `Localizable.strings (en/ko)` | 17개 문자열 추가 |                                                                                                                                                                                             
                                                                                                                                                                                                                                                   
  ## Test plan                                                                                                                                                                                                                                     
  - [ ] Browse 탭에서 검색바에 "heart" 입력 → heart 관련 심볼만 표시                                                                                                                                                                               
  - [ ] 카테고리 칩 "날씨" 선택 → cloud/sun/moon 등 필터링 확인                                                                                                                                                                                    
  - [ ] 카테고리 + 검색어 조합 필터링 동작 확인                                                                                                                                                                                                    
  - [ ] 검색 결과 없을 때 빈 상태 UI 표시 확인                                                                                                                                                                                                     
  - [ ] Draw 탭에서 결과 클릭 → SFSymbolListView 기존 동작 정상 확인                                                                                                                                                                               
  - [ ] 영어/한국어 전환 시 카테고리명 로컬라이즈 확인                                                                                                                                                                                             
                                                                                                                                                                                                                                                   
  Closes #18 